### PR TITLE
Fix bug of repo name for examples

### DIFF
--- a/examples/aws/ca/main.tf
+++ b/examples/aws/ca/main.tf
@@ -1,5 +1,5 @@
 module "ca" {
-  source = "git@github.com:scalar-labs/scalardl-terraform.git//modules/aws/ca?ref=master"
+  source = "git@github.com:scalar-labs/scalar-terraform.git//modules/aws/ca?ref=master"
   #source = "../../../modules/aws/ca"
 
   # Required Variables (Use remote state)

--- a/examples/aws/cassandra/main.tf
+++ b/examples/aws/cassandra/main.tf
@@ -1,5 +1,5 @@
 module "cassandra" {
-  source = "git@github.com:scalar-labs/scalardl-terraform.git//modules/aws/cassandra?ref=master"
+  source = "git@github.com:scalar-labs/scalar-terraform.git//modules/aws/cassandra?ref=master"
   #source = "../../../modules/aws/cassandra"
 
   # Required Variables (Use network remote state)

--- a/examples/aws/monitor/main.tf
+++ b/examples/aws/monitor/main.tf
@@ -1,5 +1,5 @@
 module "monitor" {
-  source = "git@github.com:scalar-labs/scalardl-terraform.git//modules/aws/monitor?ref=master"
+  source = "git@github.com:scalar-labs/scalar-terraform.git//modules/aws/monitor?ref=master"
   #source = "../../../modules/aws/monitor"
 
   # Required Variables (Use remote state)

--- a/examples/aws/scalardl/main.tf
+++ b/examples/aws/scalardl/main.tf
@@ -1,5 +1,5 @@
 module "scalardl" {
-  source = "git@github.com:scalar-labs/scalardl-terraform.git//modules/aws/scalardl?ref=master"
+  source = "git@github.com:scalar-labs/scalar-terraform.git//modules/aws/scalardl?ref=master"
   #source = "../../../modules/aws/scalardl"
 
   # Required Variables (Use remote state)


### PR DESCRIPTION
I fixed bug of repo name for examples.
`scalardl-terraform` -> `scalar-terraform`