### PR TITLE
Add ci test for network

### DIFF
--- a/.github/workflows/aws_network.yml
+++ b/.github/workflows/aws_network.yml
@@ -7,6 +7,8 @@ on:
       - 'modules/aws/network/**'
       - 'modules/universal/bastion/**'
       - 'modules/universal/name-generator/**'
+      - 'test/modules/awsdeploy/network/**'
+      - 'provision/**'
   push:
     branches:
       - master
@@ -14,6 +16,8 @@ on:
       - 'modules/aws/network/**'
       - 'modules/universal/bastion/**'
       - 'modules/universal/name-generator/**'
+      - 'test/modules/awsdeploy/network/**'
+      - 'provision/**'
 jobs:
   terraform:
     name: 'Terraform'


### PR DESCRIPTION
Added ci test(fmt, init, validate,plan) of network module that works in the github actions.
https://scalar-labs.atlassian.net/browse/DLT-4788

Note. Use the same modules as the integration test.