### PR TITLE
Fix install fail in scalardl

### DIFF
--- a/modules/universal/scalardl/provision/Dockerfile
+++ b/modules/universal/scalardl/provision/Dockerfile
@@ -4,7 +4,7 @@ FROM ${FROM_SCALAR_IMAGE}:${FROM_SCALAR_TAG}
 
 
 #Install cqlsh tool
-RUN apt-get update && apt-get install -y curl gnupg \
+RUN apt-get update && apt-get install -y curl gnupg apt-transport-https \
     && echo "deb https://downloads.apache.org/cassandra/debian 311x main" > /etc/apt/sources.list.d/cassandra.sources.list \
     && curl -fsSL https://downloads.apache.org/cassandra/KEYS | apt-key add - \
     && apt-get update && apt-get install -y cassandra-tools \


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-5289

# Done
- Added `apt-transport-https` packages.
Bug of below PR. (Sorry!)
https://github.com/scalar-labs/scalar-terraform/pull/33

# Confirm
```
$ cd scalar-terraform/modules/universal/scalardl/provision
$ SCALAR_IMAGE=scalar-ledger-provision:2.0.2 docker-compose build --build-arg FROM_SCALAR_IMAGE=scalarlabs/scalar-ledger --build-arg FROM_SCALAR_TAG=2.0.2 && docker save scalar-ledger-provision:2.0.2
```