### PR TITLE
Update Envoy CORS config

### DIFF
--- a/modules/universal/envoy/provision/envoy-tls.yaml
+++ b/modules/universal/envoy/provision/envoy-tls.yaml
@@ -47,10 +47,9 @@ static_resources:
                     cors:
                       allow_origin: ["*"]
                       allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                      allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web
+                      allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                       max_age: "1728000"
-                      expose_headers: custom-header-1,grpc-status,grpc-message
-                      enabled: true
+                      expose_headers: grpc-status,grpc-message,rpc.status-bin
           tls_context:
             common_tls_context:
               alpn_protocols:      "h2"

--- a/modules/universal/envoy/provision/envoy.yaml
+++ b/modules/universal/envoy/provision/envoy.yaml
@@ -47,10 +47,9 @@ static_resources:
                     cors:
                       allow_origin: ["*"]
                       allow_methods: GET, PUT, DELETE, POST, OPTIONS
-                      allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web
+                      allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
                       max_age: "1728000"
-                      expose_headers: custom-header-1,grpc-status,grpc-message
-                      enabled: true
+                      expose_headers: grpc-status,grpc-message,rpc.status-bin
   clusters:
     - name:                        scalar-service
       connect_timeout:             0.25s


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-5270

* Adds `rpc.status-bin` header to `expose_headers` for scalardl-web-client-sdk
  https://github.com/scalar-labs/scalardl-web-client-sdk#envoy-configuration
* Updates cors section based on this example: https://github.com/grpc/grpc-web/blob/master/net/grpc/gateway/examples/helloworld/envoy.yaml
* Removes an example header `custom-header-1`
