### PR TITLE
Persist Cassy's data directory

### DIFF
--- a/modules/universal/cassy/provision/docker-compose.yml
+++ b/modules/universal/cassy/provision/docker-compose.yml
@@ -7,5 +7,6 @@ services:
       - "20051:20051"
     volumes:
       - ./conf:/cassy/conf
+      - ./data:/cassy/data
       - ~/.ssh/cassy.pem:/opt/cassy/cassy.pem
     restart: always


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-5411

Adds a volumes entry to docker-compose.yml so that `docker.db` file can be persisted across restarts of the Docker container.