### PR TITLE
Use Standard_B2s type for Cassy host on Azure

### DIFF
--- a/examples/azure/cassandra/example.tfvars
+++ b/examples/azure/cassandra/example.tfvars
@@ -18,7 +18,7 @@ cassandra = {
 }
 
 cassy = {
-  # resource_type             = "Standard_D2s_v3"
+  # resource_type             = "Standard_B2s"
   # resource_count            = 1
   # resource_root_volume_size = 64
   # enable_tdagent            = true

--- a/modules/azure/cassandra/locals.tf
+++ b/modules/azure/cassandra/locals.tf
@@ -85,7 +85,7 @@ locals {
 ### cassy
 locals {
   cassy_default = {
-    resource_type             = "Standard_D2s_v3"
+    resource_type             = "Standard_B2s"
     resource_count            = 1
     resource_root_volume_size = 64
     enable_tdagent            = true


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-5412

This is additional to #60. Changes the type of the Cassy instance on Azure.