### PR TITLE
Fix select ami bug in shared aws account

### DIFF
--- a/modules/aws/network/ami-selector/main.tf
+++ b/modules/aws/network/ami-selector/main.tf
@@ -6,9 +6,4 @@ data "aws_ami" "image" {
     name   = "name"
     values = [var.name]
   }
-
-  filter {
-    name   = "tag:Env"
-    values = ["production"]
-  }
 }


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-5417

I removed tag filter for select ami. Because shared account can't get tag name.