### PR TITLE
Add slack notify for terratest

### DIFF
--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -52,7 +52,6 @@ jobs:
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_CHANNEL: eng-notification
-          SLACK_ICON: ':robot_face:'
           SLACK_COLOR: danger
           SLACK_MESSAGE: ${{ job.status }}
           SLACK_TITLE: Integration test for AWS

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -53,7 +53,6 @@ jobs:
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_CHANNEL: eng-notification
-          SLACK_ICON: ':robot_face:'
           SLACK_COLOR: danger
           SLACK_MESSAGE: ${{ job.status }}
           SLACK_TITLE: Integration test for Azure


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-5533

# Done
- Notify slack when terratest fails
  - Channel: `eng-notification`
  - Condition: only in case of failure
  - `SLACK_WEBHOOK_URL`:  It needs to be set in the secrets of github actions.

# Confirm
e.g.
<img width="544" alt="Screen Shot 2020-03-25 at 12 32 10" src="https://user-images.githubusercontent.com/12690752/77499193-c35ba600-6e94-11ea-8edb-2a065069b997.png">

# Refs
https://github.com/rtCamp/action-slack-notify