### PR TITLE
Fix hostname bug in td-agent config of cassandra

### DIFF
--- a/provision/ansible/playbooks/templates/cassandra-server/td-agent.conf.j2
+++ b/provision/ansible/playbooks/templates/cassandra-server/td-agent.conf.j2
@@ -20,7 +20,7 @@
 <filter **>
   @type record_transformer
   <record>
-    hostname {{ monitor_host }}
+    hostname ${hostname}
   </record>
 </filter>
 


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-5593

Fixed hostname bug in td-agent configuration. (Sorry! Just my mistake.)