### PR TITLE
Fix filename for envoy of terratest

### DIFF
--- a/test/modules/envoy_config/envoy.yaml.j2
+++ b/test/modules/envoy_config/envoy.yaml.j2
@@ -82,7 +82,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: scalardl.internal.scalar-labs.com
+                      address: scalardl.{{ internal_domain }}
                       port_value: 50051
     - name: scalar-privileged
       connect_timeout: 0.25s
@@ -107,7 +107,7 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: scalardl.internal.scalar-labs.com
+                      address: scalardl.{{ internal_domain }}
                       port_value: 50052
     - name: monitor
       connect_timeout: 0.25s
@@ -123,5 +123,5 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: monitor.internal.scalar-labs.com
+                      address: monitor.{{ internal_domain }}
                       port_value: 9090


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-5702

Sorry! Just my mistake. 
Fixed filename of envoy.yaml to *.j2.

```
[centos@envoy-1 ~]$ docker ps
CONTAINER ID        IMAGE                      COMMAND                  CREATED             STATUS              PORTS                                                         NAMES
9cd4b27bf6f0        envoyproxy/envoy:v1.12.3   "/docker-entrypoint.…"   25 minutes ago      Up 2 minutes        0.0.0.0:9001->9001/tcp, 0.0.0.0:50051->50051/tcp, 10000/tcp   provision_envoy_1
```