### PR TITLE
Add date string for search ami

### DIFF
--- a/modules/aws/network/ami-selector/vars.tf
+++ b/modules/aws/network/ami-selector/vars.tf
@@ -7,5 +7,5 @@ variable "owners" {
 }
 
 variable "name" {
-  default = "CentOS Linux 7 x86_64*"
+  default = "CentOS Linux 7 x86_64 - 20200407*"
 }


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-5715
Fix default search name to `CentOS Linux 7 x86_64 - 20200407*`.