### PR TITLE
Fix duplicate copy bug for playbooks

### DIFF
--- a/modules/universal/ca/main.tf
+++ b/modules/universal/ca/main.tf
@@ -38,7 +38,7 @@ resource "null_resource" "docker_install" {
 
   provisioner "remote-exec" {
     inline = [
-      "cd ${module.ansible.remote_playbook_path}",
+      "cd ${module.ansible.remote_playbook_path}/playbooks",
       "ansible-playbook -u ${var.user_name} -i ${var.host_list[count.index]}, docker-server.yml -e enable_tdagent=${var.enable_tdagent ? 1 : 0} -e monitor_host=monitor.${var.internal_domain}",
     ]
   }

--- a/modules/universal/cassandra/main.tf
+++ b/modules/universal/cassandra/main.tf
@@ -40,7 +40,7 @@ resource "null_resource" "cassandra" {
 
   provisioner "remote-exec" {
     inline = [
-      "cd ${module.ansible.remote_playbook_path}",
+      "cd ${module.ansible.remote_playbook_path}/playbooks",
       "echo '${var.cassy_public_key}' > cassandra.pub",
       "ansible-playbook -u ${var.user_name} -i ${var.host_list[count.index]}, cassandra-server.yml -e CASSANDRA_MEMTABLE_THRESHOLD=${var.memtable_threshold} -e CASSANDRA_SEEDS=${join(",", var.host_seed_list)} -e enable_tdagent=${var.enable_tdagent ? 1 : 0} -e CASSANDRA_STATE=${var.start_on_initial_boot ? "started" : "stopped"} -e monitor_host=monitor.${var.internal_domain}",
     ]

--- a/modules/universal/cassy/main.tf
+++ b/modules/universal/cassy/main.tf
@@ -43,7 +43,7 @@ resource "null_resource" "docker_install" {
 
   provisioner "remote-exec" {
     inline = [
-      "cd ${module.ansible.remote_playbook_path}",
+      "cd ${module.ansible.remote_playbook_path}/playbooks",
       "ansible-playbook -u ${var.user_name} -i ${var.host_list[count.index]}, docker-server.yml -e enable_tdagent=${var.enable_tdagent ? 1 : 0} -e monitor_host=monitor.${var.internal_domain}",
     ]
   }

--- a/modules/universal/envoy/main.tf
+++ b/modules/universal/envoy/main.tf
@@ -42,7 +42,7 @@ resource "null_resource" "docker_install" {
 
   provisioner "remote-exec" {
     inline = [
-      "cd ${module.ansible.remote_playbook_path}",
+      "cd ${module.ansible.remote_playbook_path}/playbooks",
       "ansible-playbook -u ${var.user_name} -i ${var.host_list[count.index]}, docker-server.yml -e enable_tdagent=${var.enable_tdagent ? 1 : 0} -e monitor_host=monitor.${var.internal_domain}",
     ]
   }

--- a/modules/universal/monitor/main.tf
+++ b/modules/universal/monitor/main.tf
@@ -41,7 +41,7 @@ resource "null_resource" "docker_install" {
 
   provisioner "remote-exec" {
     inline = [
-      "cd ${module.ansible.remote_playbook_path}",
+      "cd ${module.ansible.remote_playbook_path}/playbooks",
       "ansible-playbook -u ${var.user_name} -i ${var.host_list[count.index]}, monitor-server.yml --extra-vars='enable_tdagent=${var.enable_tdagent ? 1 : 0}'",
     ]
   }

--- a/modules/universal/reaper/main.tf
+++ b/modules/universal/reaper/main.tf
@@ -38,7 +38,7 @@ resource "null_resource" "docker_install" {
 
   provisioner "remote-exec" {
     inline = [
-      "cd ${module.ansible.remote_playbook_path}",
+      "cd ${module.ansible.remote_playbook_path}/playbooks",
       "ansible-playbook -u ${var.user_name} -i ${var.host_list[count.index]}, docker-server.yml -e enable_tdagent=${var.enable_tdagent ? 1 : 0} -e monitor_host=monitor.${var.internal_domain}",
     ]
   }

--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -90,7 +90,7 @@ resource "null_resource" "docker_install" {
 
   provisioner "remote-exec" {
     inline = [
-      "cd ${module.ansible.remote_playbook_path}",
+      "cd ${module.ansible.remote_playbook_path}/playbooks",
       "ansible-playbook -u ${var.user_name} -i ${var.host_list[count.index]}, docker-server.yml -e enable_tdagent=${var.enable_tdagent ? 1 : 0} -e monitor_host=monitor.${var.internal_domain}",
     ]
   }

--- a/provision/ansible/main.tf
+++ b/provision/ansible/main.tf
@@ -2,4 +2,3 @@ locals {
   module_playbooks = "${path.module}/playbooks"
   playbook_path    = var.local_playbook_path == "" ? local.module_playbooks : var.local_playbook_path
 }
-

--- a/provision/ansible/vars.tf
+++ b/provision/ansible/vars.tf
@@ -1,8 +1,7 @@
 variable "remote_playbook_path" {
-  default = "~/playbooks"
+  default = "~/"
 }
 
 variable "local_playbook_path" {
   default = ""
 }
-


### PR DESCRIPTION
# Description

From the second time, `playbooks` copied to `/home/centos/playbooks/playbooks`.

```
[centos@bastion-1 ~]$ tree -L 2 /home/centos/playbooks/
/home/centos/playbooks/
├── ansible.cfg
├── bastion-server.yml
├── cassandra-server.yml
├── docker-server.yml
├── files
│   ├── monitor-server
├── monitor-server.yml
├── playbooks
│   ├── ansible.cfg
│   ├── bastion-server.yml
│   ├── cassandra-server.yml
│   ├── docker-server.yml
│   ├── files
│   ├── monitor-server.yml
│   ├── roles
│   └── templates
├── roles
│   ├── ansible
│   ├── cassandra
│   ├── common
│   ├── docker
│   ├── java
│   ├── td-agent
│   └── td-agent_aggregation
└── templates
    ├── bastion-server
    ├── cassandra-server
    └── docker-server
```