### PR TITLE
Fix volume tags bug

### DIFF
--- a/modules/aws/ca/main.tf
+++ b/modules/aws/ca/main.tf
@@ -12,6 +12,7 @@ module "ca_cluster" {
   subnet_id                   = local.subnet_id
   associate_public_ip_address = false
   hostname_prefix             = "ca"
+  use_num_suffix              = true
 
   tags = merge(
     var.custom_tags,

--- a/modules/aws/cassandra/cassandra.tf
+++ b/modules/aws/cassandra/cassandra.tf
@@ -12,6 +12,7 @@ module "cassandra_cluster" {
   subnet_id                   = local.subnet_id
   associate_public_ip_address = false
   hostname_prefix             = "cassandra"
+  use_num_suffix              = true
 
   tags = merge(
     var.custom_tags,

--- a/modules/aws/cassandra/cassandra.tf
+++ b/modules/aws/cassandra/cassandra.tf
@@ -49,7 +49,7 @@ resource "aws_ebs_volume" "cassandra_data_volume" {
   tags = merge(
     var.custom_tags,
     {
-      Name      = "${local.network_name} Cassandra data-${count.index + 1}"
+      Name      = "${local.network_name} Cassandra Cluster-${count.index + 1}"
       Terraform = "true"
       Network   = local.network_name
     }
@@ -120,7 +120,7 @@ resource "aws_ebs_volume" "cassandra_commitlog_volume" {
   tags = merge(
     var.custom_tags,
     {
-      Name      = "${local.network_name} Cassandra commitlog-${count.index + 1}"
+      Name      = "${local.network_name} Cassandra Cluster-${count.index + 1}"
       Terraform = "true"
       Network   = local.network_name
     }

--- a/modules/aws/cassandra/cassy.tf
+++ b/modules/aws/cassandra/cassy.tf
@@ -12,6 +12,7 @@ module "cassy_cluster" {
   subnet_id                   = local.subnet_id
   associate_public_ip_address = false
   hostname_prefix             = "cassy"
+  use_num_suffix              = true
 
   tags = merge(
     var.custom_tags,

--- a/modules/aws/cassandra/reaper.tf
+++ b/modules/aws/cassandra/reaper.tf
@@ -12,6 +12,7 @@ module "reaper_cluster" {
   subnet_id                   = local.subnet_id
   associate_public_ip_address = false
   hostname_prefix             = "reaper"
+  use_num_suffix              = true
 
   tags = merge(
     var.custom_tags,

--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -12,6 +12,7 @@ module "monitor_cluster" {
   subnet_id                   = local.subnet_id
   associate_public_ip_address = false
   hostname_prefix             = "monitor"
+  use_num_suffix              = true
 
   tags = merge(
     var.custom_tags,
@@ -50,7 +51,7 @@ resource "aws_ebs_volume" "monitor_log_volume" {
   tags = merge(
     var.custom_tags,
     {
-      Name      = "${local.network_name} Monitor log"
+      Name      = "${local.network_name} Monitor Cluster-${count.index + 1}"
       Terraform = "true"
       Network   = local.network_name
     }

--- a/modules/aws/network/bastion/main.tf
+++ b/modules/aws/network/bastion/main.tf
@@ -17,6 +17,7 @@ module "bastion_cluster" {
   subnet_id                   = var.subnet_id
   associate_public_ip_address = true
   hostname_prefix             = "bastion"
+  use_num_suffix              = true
 
   tags = merge(
     var.custom_tags,

--- a/modules/aws/scalardl/cluster/main.tf
+++ b/modules/aws/scalardl/cluster/main.tf
@@ -12,6 +12,7 @@ module "scalardl_cluster" {
   subnet_id                   = var.subnet_id
   associate_public_ip_address = false
   hostname_prefix             = "scalardl-${var.resource_cluster_name}"
+  use_num_suffix              = true
 
   tags = merge(
     var.custom_tags,

--- a/modules/aws/scalardl/envoy.tf
+++ b/modules/aws/scalardl/envoy.tf
@@ -12,6 +12,7 @@ module "envoy_cluster" {
   subnet_id                   = local.envoy.subnet_id
   associate_public_ip_address = false
   hostname_prefix             = "envoy"
+  use_num_suffix              = true
 
   tags = merge(
     var.custom_tags,


### PR DESCRIPTION
# Description

The following will be repeated forever.
- first apply
```
  # module.cassandra.module.cassandra_cluster.aws_instance.this[0] will be updated in-place
  ~ resource "aws_instance" "this" {
        ami                          = "ami-092569e9fa1620c4d"
・・・
volume_tags   = {
  ~ "Name"      = "tei-aws-8nzfdqe Cassandra commitlog-1" -> "tei-aws-8nzfdqe Cassandra Cluster-1"
    "Network"   = "tei-aws-8nzfdqe"
    "Terraform" = "true"
}
```
- second apply
```
  # module.cassandra.aws_ebs_volume.cassandra_commitlog_volume[0] will be updated in-place
  ~ resource "aws_ebs_volume" "cassandra_commitlog_volume" {
        arn               = "arn:aws:ec2:ap-northeast-1:825543958249:volume/vol-0eea7e6e098aa5b6f"
        availability_zone = "ap-northeast-1a"
        encrypted         = false
        id                = "vol-0eea7e6e098aa5b6f"
        iops              = 192
        size              = 64
      ~ tags              = {
          ~ "Name"      = "tei-aws-8nzfdqe Cassandra Cluster-1" -> "tei-aws-8nzfdqe Cassandra commitlog-1"
            "Network"   = "tei-aws-8nzfdqe"
            "Terraform" = "true"
        }
        type              = "gp2"
    }
```

# Done

- Don't distinguish between data and commit volumes by name.
- Fix `use_num_suffix` to `true`.
Always add suffix. (e.g.`tei-aws-8nzfdqe Cassy Cluster-1`)