### PR TITLE
Fix cassy module bugs

### DIFF
--- a/modules/universal/cassy/main.tf
+++ b/modules/universal/cassy/main.tf
@@ -72,7 +72,7 @@ resource "null_resource" "cassy_container" {
   provisioner "remote-exec" {
     inline = [
       "echo '${tls_private_key.cassy_private_key.private_key_pem}' > $HOME/.ssh/cassy.pem",
-      "chmod 400 $HOME/.ssh/cassy.pem",
+      "chmod 600 $HOME/.ssh/cassy.pem",
       "cd $HOME/cassy",
       "docker-compose up -d",
     ]

--- a/modules/universal/cassy/main.tf
+++ b/modules/universal/cassy/main.tf
@@ -65,7 +65,7 @@ resource "null_resource" "cassy_container" {
   }
 
   provisioner "file" {
-    source      = "${path.module}/provision"
+    source      = "${path.module}/provision/"
     destination = "$HOME/cassy"
   }
 


### PR DESCRIPTION
This PR addresses two minor bugs of cassy module.

When applied after `null_resource.cassy_container[0]` is tainted:

1. `~/cassy/` directory is not updated correctly. It creates `~/cassy/provision/` instead.
2. The Cassy private key is read-only, so the `echo {key} > ~/.ssh/cassy.pem` command fails and the container cannot be started.