### PR TITLE
Fix cassy directory bug

### DIFF
--- a/docs/CassySetup.md
+++ b/docs/CassySetup.md
@@ -16,7 +16,7 @@ Cassy master tells each Cassandra node to upload backup files to Cloud Storages 
 
 1. Shutdown the docker container
     ```
-    $ cd cassy
+    $ cd provision
     $ docker-compose down
     ```
 

--- a/modules/universal/cassy/main.tf
+++ b/modules/universal/cassy/main.tf
@@ -65,15 +65,15 @@ resource "null_resource" "cassy_container" {
   }
 
   provisioner "file" {
-    source      = "${path.module}/provision/"
-    destination = "$HOME/cassy"
+    source      = "${path.module}/provision"
+    destination = "$HOME"
   }
 
   provisioner "remote-exec" {
     inline = [
       "echo '${tls_private_key.cassy_private_key.private_key_pem}' > $HOME/.ssh/cassy.pem",
       "chmod 600 $HOME/.ssh/cassy.pem",
-      "cd $HOME/cassy",
+      "cd $HOME/provision",
       "docker-compose up -d",
     ]
   }


### PR DESCRIPTION
# Description

Related this PR.
https://github.com/scalar-labs/scalar-terraform/pull/106

another solution.
```
### Create directory first.
provisioner "remote-exec" {
    inline = ["mkdir -p $HOME/cassy"]
  }
```