### PR TITLE
Fix create nlb bug in multi-az

### DIFF
--- a/modules/aws/network/locals.tf
+++ b/modules/aws/network/locals.tf
@@ -19,6 +19,8 @@ locals {
 }
 
 locals {
+  locations = distinct(var.locations)
+
   subnet_map = {
     public         = cidrsubnets(cidrsubnet(local.network.cidr, 8, 0), 2, 2, 2)
     private        = cidrsubnets(cidrsubnet(local.network.cidr, 8, 1), 2, 2, 2)

--- a/modules/aws/network/main.tf
+++ b/modules/aws/network/main.tf
@@ -8,7 +8,7 @@ module "vpc" {
   version = "~> v2.0"
 
   cidr = local.network.cidr
-  azs  = var.locations
+  azs  = local.locations
 
   private_subnets = concat(
     local.subnet_map.private,

--- a/modules/aws/network/output.tf
+++ b/modules/aws/network/output.tf
@@ -50,7 +50,7 @@ output "bastion_ip" {
 }
 
 output "locations" {
-  value       = var.locations
+  value       = local.locations
   description = "The AWS availability zone to deploy environment."
 }
 

--- a/modules/aws/scalardl/locals.tf
+++ b/modules/aws/scalardl/locals.tf
@@ -109,5 +109,5 @@ locals {
 
   envoy_create_count     = local.envoy.resource_count > 0 ? 1 : 0
   envoy_nlb_create_count = local.envoy.enable_nlb ? 1 : 0
-  envoy_nlb_subnet_ids   = local.envoy.nlb_internal ? slice(local.private_subnet_ids, 0, length(local.locations) : slice(local.public_subnet_ids, 0, length(local.locations)
+  envoy_nlb_subnet_ids   = local.envoy.nlb_internal ? slice(local.private_subnet_ids, 0, length(local.locations)) : slice(local.public_subnet_ids, 0, length(local.locations))
 }

--- a/modules/aws/scalardl/locals.tf
+++ b/modules/aws/scalardl/locals.tf
@@ -109,5 +109,5 @@ locals {
 
   envoy_create_count     = local.envoy.resource_count > 0 ? 1 : 0
   envoy_nlb_create_count = local.envoy.enable_nlb ? 1 : 0
-  envoy_nlb_subnet_ids   = local.envoy.nlb_internal ? local.private_subnet_ids : local.public_subnet_ids
+  envoy_nlb_subnet_ids   = local.envoy.nlb_internal ? slice(local.private_subnet_ids, 0, length(local.locations) : slice(local.public_subnet_ids, 0, length(local.locations)
 }


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-5847

# Reproduce

1. `example.tfvars` in network module (distinct(locations) < 3)
```
locations = [
  "ap-northeast-1a",
  "ap-northeast-1c",
]
```
2. Create netowrk resources.
Result:
```
subnet_map = {
  "public" = [
    "subnet-1",   # ap-northeast-1a
    "subnet-2",  # ap-northeast-1c
    "subnet-3",  # ap-northeast-1a
  ]
```
3. Create cassandra resources.
4. Create sclardl resources.
  Failure to create envoy NLB. Because `subnet-1` and `subnet-3` in same az(`ap-northeast-1a`)
    ```
    A load balancer cannot be attached to multiple subnets in the same Availability Zone
    ```