### PR TITLE
Fix cassandra slow startup

### DIFF
--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -7,4 +7,4 @@ CASSANDRA_STATE: stopped
 cassandra_dc_id: dc1
 cassandra_rack_id: rack1
 endpoint_snitch: GossipingPropertyFileSnitch
-vm_max_map_count: 1048575
+vm_max_map_count: '1048575'

--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 tuned_profile: virtual-guest
+# Only Cassandra disks are tuned and OS disks are not tuned.
 # In AWS, sda and xvda are used depending on virtualization types.
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html#available-ec2-device-names
-# In Azure, sda is used.
+# In Azure, sda is used for OS.
 tuned_disk_devices: '!sda, !xvda'
 disk_read_ahead: 8
 CASSANDRA_MEMTABLE_THRESHOLD: 0.33

--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -1,8 +1,10 @@
 ---
 tuned_profile: virtual-guest
+tuned_disk_devices: '!sda, !xvda'
 disk_read_ahead: 8
 CASSANDRA_MEMTABLE_THRESHOLD: 0.33
 CASSANDRA_STATE: stopped
 cassandra_dc_id: dc1
 cassandra_rack_id: rack1
 endpoint_snitch: GossipingPropertyFileSnitch
+vm_max_map_count: 1048575

--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 tuned_profile: virtual-guest
+# In AWS, sda and xvda are used depending on virtualization types.
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html#available-ec2-device-names
+# In Azure, sda is used.
 tuned_disk_devices: '!sda, !xvda'
 disk_read_ahead: 8
 CASSANDRA_MEMTABLE_THRESHOLD: 0.33

--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -29,6 +29,13 @@
 - name: Set Active Tuned Profile to Cassandra
   command: "tuned-adm profile cassandra"
 
+- sysctl:
+    name: vm.max_map_count
+    value: "{{ vm_max_map_count }}"
+    sysctl_set: yes
+    state: present
+    reload: yes
+
 - name: Copy Cassy Backup Tool
   copy:
     src: cassy

--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -29,7 +29,8 @@
 - name: Set Active Tuned Profile to Cassandra
   command: "tuned-adm profile cassandra"
 
-- sysctl:
+- name: Set vm.max_map_count
+  sysctl:
     name: vm.max_map_count
     value: "{{ vm_max_map_count }}"
     sysctl_set: yes

--- a/provision/ansible/playbooks/roles/cassandra/templates/tuned.conf.j2
+++ b/provision/ansible/playbooks/roles/cassandra/templates/tuned.conf.j2
@@ -4,4 +4,5 @@ include={{ tuned_profile }}
 
 [disk]
 type=disk
+devices={{ tuned_disk_devices }}
 readahead={{ disk_read_ahead }}


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-5265

# Done
- Add `'!sda, !xvda'` to tuned.conf
- Add vm.max_map_count (default 65530 -> 1048575)
```
WARN  [main] 2020-04-27 08:49:55,673 StartupChecks.java:311 - Maximum number of memory map areas per process (vm.max_map_count) 65530 is too low, recommended value: 1048575, you can change it with sysctl.

```

# Confirm
- `tuned.conf`
```
[centos@cassandra-1 etc]$ cat /etc/tuned/cassandra/tuned.conf
[main]
summary=A tuned profile for Cassandra Server
include=virtual-guest

[disk]
type=disk
devices=!sda, !xvda
readahead=8
```
- `sysctl.conf`
```
[centos@cassandra-1 etc]$ cat /etc/sysctl.conf
# sysctl settings are defined through files in
# /usr/lib/sysctl.d/, /run/sysctl.d/, and /etc/sysctl.d/.
#
# Vendors settings live in /usr/lib/sysctl.d/.
# To override a whole file, create a new file with the same in
# /etc/sysctl.d/ and put new settings there. To override
# only specific settings, add a file with a lexically later
# name in /etc/sysctl.d/ and put new settings there.
#
# For more information, see sysctl.conf(5) and sysctl.d(5).
vm.max_map_count=1048575
```
- `lsblk`
```
[centos@cassandra-1 etc]$ lsblk --output NAME,KNAME,TYPE,MAJ:MIN,FSTYPE,SIZE,RA,MOUNTPOINT,LABEL
NAME   KNAME TYPE MAJ:MIN FSTYPE  SIZE  RA MOUNTPOINT    LABEL
fd0    fd0   disk   2:0             4K 128
sda    sda   disk   8:0            64G 128
├─sda1 sda1  part   8:1   xfs     500M 128 /boot
└─sda2 sda2  part   8:2   xfs    29.5G 128 /
sdb    sdb   disk   8:16           64G   8
└─sdb1 sdb1  part   8:17  ext4     64G   8 /mnt/resource
sdc    sdc   disk   8:32            1T   8
sr0    sr0   rom   11:0           628K 128
```
- `cassandra.log`
```
INFO  [main] 2020-04-28 02:35:53,456 CassandraDaemon.java:506 - JVM Arguments: [-Xloggc:/var/log/cassandra/gc.log, -ea, -XX:+UseThreadPriorities, -XX:ThreadPriorityPolicy=42, -XX:+HeapDumpOnOutOfMemoryError, -Xss256k, -XX:StringTableSize=1000003, -XX:+AlwaysPreTouch, -XX:-UseBiasedLocking, -XX:+UseTLAB, -XX:+ResizeTLAB, -XX:+UseNUMA, -XX:+PerfDisableSharedMem, -Djava.net.preferIPv4Stack=true, -XX:+UseParNewGC, -XX:+UseConcMarkSweepGC, -XX:+CMSParallelRemarkEnabled, -XX:SurvivorRatio=8, -XX:MaxTenuringThreshold=1, -XX:CMSInitiatingOccupancyFraction=75, -XX:+UseCMSInitiatingOccupancyOnly, -XX:CMSWaitDuration=10000, -XX:+CMSParallelInitialMarkEnabled, -XX:+CMSEdenChunksRecordAlways, -XX:+CMSClassUnloadingEnabled, -XX:+PrintGCDetails, -XX:+PrintGCDateStamps, -XX:+PrintHeapAtGC, -XX:+PrintTenuringDistribution, -XX:+PrintGCApplicationStoppedTime, -XX:+PrintPromotionFailure, -XX:+UseGCLogFileRotation, -XX:NumberOfGCLogFiles=10, -XX:GCLogFileSize=10M, -Dcom.sun.management.jmxremote.authenticate=false, -Dcassandra.jmx.remote.port=7199, -Dcom.sun.management.jmxremote.rmi.port=7199, -Xms16G, -Xmx16G, -Xmn400M, -XX:+UseCondCardMark, -XX:CompileCommandFile=/etc/cassandra/conf/hotspot_compiler, -javaagent:/usr/share/cassandra/lib/jamm-0.3.0.jar, -Dcassandra.jmx.local.port=7199, -Dcom.sun.management.jmxremote.authenticate=false, -Dcom.sun.management.jmxremote.password.file=/etc/cassandra/jmxremote.password, -Djava.library.path=/usr/share/cassandra/lib/sigar-bin, -Dcassandra.libjemalloc=/usr/lib64/libjemalloc.so.1, -XX:OnOutOfMemoryError=kill -9 %p, -Dlogback.configurationFile=logback.xml, -Dcassandra.logdir=/var/log/cassandra, -Dcassandra.storagedir=, -Dcassandra-pidfile=/var/run/cassandra/cassandra.pid]
INFO  [main] 2020-04-28 02:35:55,988 NativeLibrary.java:176 - JNA mlockall successful
INFO  [main] 2020-04-28 02:35:55,989 StartupChecks.java:140 - jemalloc seems to be preloaded from /usr/lib64/libjemalloc.so.1
```

# Refs
https://www.ibm.com/support/knowledgecenter/SS8G7U_19.4.0/com.ibm.app.mgmt.doc/content/install_storage_cassandra.html
https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/device_naming.html#available-ec2-device-names
https://docs.microsoft.com/ja-jp/azure/virtual-machines/linux/optimization#azure-os-disk
https://docs.datastax.com/en/dse/5.1/dse-admin/datastax_enterprise/config/configRecommendedSettings.html
