### PR TITLE
Fix create subnet bug in 2az

### DIFF
--- a/modules/aws/network/locals.tf
+++ b/modules/aws/network/locals.tf
@@ -19,7 +19,9 @@ locals {
 }
 
 locals {
-  locations = distinct(var.locations)
+  dist_locations = distinct(var.locations)
+
+  locations = length(local.dist_locations) == 2 ? concat(local.dist_locations, [local.dist_locations[0]]) : local.dist_locations
 
   subnet_map = {
     public         = cidrsubnets(cidrsubnet(local.network.cidr, 8, 0), 2, 2, 2)


### PR DESCRIPTION
# Description

https://github.com/terraform-aws-modules/terraform-aws-vpc/blob/23b0a02d2a3225a05ddf5f31d9a32728bf5505c3/main.tf#L316
https://www.terraform.io/docs/configuration/functions/element.html#examples
```
If the given index is greater than the length of the list then the index is "wrapped around" by taking the index modulo the length of the list:
```

- example.tfvars
```
locations = [
  "ap-northeast-1a",
  "ap-northeast-1c",
]
```
- subnet_map
```
subnet_map = {
  "cassandra" = [
    "subnet-1",   # ap-northeast-1c  => ap-northeast-1a (expect)
    "subnet-2",  # ap-northeast-1a =>  ap-northeast-1c (expect)
    "subnet-3",  # ap-northeast-1c =>  ap-northeast-1a (expect)
  ]
・・・
}
```
- Create cassandra instances with subnet_ids
```
cassandra-1 => ap-northeast-1c
cassandra-2 => ap-northeast-1a
cassandra-3 => ap-northeast-1c
```
- Create cassandra data volume with var.locations
```
data-1 => ap-northeast-1a
data-2 => ap-northeast-1c
data-3 => ap-northeast-1a
```

**※ Can't attach because instance(`cassandra-1`) and ebs(`data-1`) in different az.**

- Done
Maybe this is a workaround.
When input `locations` is 2AZ.
```
locations = [
  "ap-northeast-1a",
  "ap-northeast-1c",
]
```
=> Add first one AZ to `locations` => 3AZ
```
locations = [
  "ap-northeast-1a",
  "ap-northeast-1c",
  "ap-northeast-1a",
]
```

- Confirm
  - test1
    ```
    locations = [
      "ap-northeast-1a",
      "ap-northeast-1c",
      "ap-northeast-1c",
    ]
    ```
  - test2
    ```
    locations = [
      "ap-northeast-1a",
      "ap-northeast-1c",
      "ap-northeast-1a",
    ]
    ```
  - test3
    ```
    locations = [
      "ap-northeast-1a",
      "ap-northeast-1a",
      "ap-northeast-1c",
    ]
    ```
  - test4
    ```
    locations = [
      "ap-northeast-1a",
      "ap-northeast-1c",
    ]
    ```
  - test5
    ```
    locations = [
      "ap-northeast-1a",
    ]
    ```
  - test6
    ```
    locations = [
      "ap-northeast-1a",
      "ap-northeast-1c",
      "ap-northeast-1d",
    ]
    ```