### PR TITLE
Fix create envoy nlb bug in 2az

### DIFF
--- a/modules/aws/scalardl/locals.tf
+++ b/modules/aws/scalardl/locals.tf
@@ -109,5 +109,5 @@ locals {
 
   envoy_create_count     = local.envoy.resource_count > 0 ? 1 : 0
   envoy_nlb_create_count = local.envoy.enable_nlb ? 1 : 0
-  envoy_nlb_subnet_ids   = local.envoy.nlb_internal ? slice(local.private_subnet_ids, 0, length(local.locations)) : slice(local.public_subnet_ids, 0, length(local.locations))
+  envoy_nlb_subnet_ids   = local.envoy.nlb_internal ? slice(local.private_subnet_ids, 0, length(distinct(local.locations))) : slice(local.public_subnet_ids, 0, length(distinct(local.locations)))
 }


### PR DESCRIPTION
# Description

Sorry! My degradation.
https://github.com/scalar-labs/scalar-terraform/pull/115

- example.tfvars
```
locations = [
  "ap-northeast-1a",
  "ap-northeast-1c",
]
```
- network.output
locations
```
[
  "ap-northeast-1a",
  "ap-northeast-1c",
  "ap-northeast-1a",
]
```
subnet_map
```
private_subent_ids = [
  "private-1", # ap-northeast-1a
  "private-2", # ap-northeast-1c
  "private-3", # ap-northeast-1a
]
```
- scalardl
```
envoy_nlb_subnet_ids   = local.envoy.nlb_internal ? slice(local.private_subnet_ids, 0, length(local.locations)) : slice(local.public_subnet_ids, 0, length(local.locations))
```
=> 
envoy_nlb_subnet_ids = [
  "private-1", # ap-northeast-1a
  "private-2", # ap-northeast-1c
  "private-3", # ap-northeast-1a
]

 **A load balancer cannot be attached to multiple subnets in the same Availability Zone**

# Done

Fix to `distinct(local.locations)`, So removing the duplicate az of subnet_ids.
```
envoy_nlb_subnet_ids = [
  "private-1", # ap-northeast-1a
  "private-2", # ap-northeast-1c
]
```