### PR TITLE
Fix bug for display grafana

### DIFF
--- a/modules/universal/monitor/main.tf
+++ b/modules/universal/monitor/main.tf
@@ -81,7 +81,7 @@ resource "null_resource" "monitor_container" {
       "export cassandra_resource_count=${var.cassandra_resource_count}",
       "export cassandra_replication_factor=${var.replication_factor}",
       "export dashboard_local_forwarding_port=8000",
-      "export grafana_datasource_url=prometheus.${var.internal_domain}:9090",
+      "export grafana_datasource_url=monitor.${var.internal_domain}:9090",
       "export internal_domain=${var.internal_domain}",
       "j2 ./prometheus/prometheus.yml.j2 > ./prometheus/prometheus.yml",
       "j2 ./prometheus/scalardl_alert.rules.yml.j2 > ./prometheus/scalardl_alert.rules.yml",


### PR DESCRIPTION
# Description

DNS `prometheus` already deleted.
https://github.com/scalar-labs/scalar-terraform/pull/101/
https://github.com/scalar-labs/scalar-terraform/pull/98

```
2020-05-07T07:55:35+00:00       docker.provision_grafana_1      {"log":"2020/05/07 07:55:35 http: proxy error: dial tcp: lookup prometheus.internal.scalar-labs.com on 127.0.0.11:53: no such host","container_id":"3a87ce68558d0bd6efbf97726249adc3e826296299eebe393009a1157c7bc554","container_name":"/provision_grafana_1","source":"stderr","hostname":"monitor-1"}
```

# Done
Fix to use `monitor` DNS for `grafana_datasource_url`.