### PR TITLE
Fix locations bug in cassandra

### DIFF
--- a/modules/aws/cassandra/cassandra.tf
+++ b/modules/aws/cassandra/cassandra.tf
@@ -198,7 +198,7 @@ module "cassandra_provision" {
   cassy_public_key      = module.cassy_provision.public_key
   start_on_initial_boot = local.cassandra.start_on_initial_boot
   internal_domain       = local.internal_domain
-  locations             = local.locations
+  locations             = distinct(local.locations)
 }
 
 resource "aws_security_group" "cassandra" {


### PR DESCRIPTION
# Description

`cassandra_rack_id` is misconfigured when `length(local.locations) = 2`.

- example.tfvars in network
```
locations = [
  "ap-northeast-1a",
  "ap-northeast-1c",
]
```
- output `locations`
```
locations = [
  "ap-northeast-1a",
  "ap-northeast-1c",
  "ap-northeast-1a",
]
```
- length(var.locations) = 3
https://github.com/scalar-labs/scalar-terraform/blob/2b36f7f02c52a0e7cce62dce7ecffde13c2ec4b2/modules/universal/cassandra/main.tf#L45
- rack_id in ["rack1","rack2","rack3","rack1",...]
correct: ["rack1","rack2","rack1",...]

# Done
Add `distinct`