### PR TITLE
Fix log volume re-attachment issue on monitor node

### DIFF
--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -70,6 +70,13 @@ resource "aws_volume_attachment" "monitor_log_volume_attachment" {
 resource "null_resource" "volume_data" {
   count = local.monitor.enable_tdagent && local.monitor.enable_log_volume ? local.monitor.resource_count : 0
 
+  triggers = {
+    volume_attachment_ids = join(
+      ",",
+      aws_volume_attachment.monitor_log_volume_attachment.*.id,
+    )
+  }
+
   connection {
     bastion_host = local.bastion_ip
     host         = module.monitor_cluster.private_ip[count.index]

--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -43,10 +43,9 @@ module "monitor_cluster" {
 resource "aws_ebs_volume" "monitor_log_volume" {
   count = local.monitor.enable_tdagent && local.monitor.enable_log_volume ? local.monitor.resource_count : 0
 
-  availability_zone = module.monitor_cluster.availability_zone[count.index]
+  availability_zone = local.locations[count.index % length(local.locations)]
   size              = local.monitor.log_volume_size
   type              = local.monitor.log_volume_type
-  depends_on        = [module.monitor_cluster]
 
   tags = merge(
     var.custom_tags,

--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -73,7 +73,7 @@ resource "null_resource" "volume_data" {
   triggers = {
     volume_attachment_ids = join(
       ",",
-      aws_volume_attachment.monitor_log_volume_attachment.*.id,
+      aws_volume_attachment.monitor_log_volume_attachment.*.id
     )
   }
 

--- a/modules/azure/monitor/main.tf
+++ b/modules/azure/monitor/main.tf
@@ -33,7 +33,6 @@ resource "azurerm_managed_disk" "monitor_log_volume" {
   storage_account_type = local.monitor.log_volume_type
   create_option        = "Empty"
   disk_size_gb         = local.monitor.log_volume_size
-  depends_on           = [module.monitor_cluster]
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "monitor_log_volume_attachment" {

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/files/drive_mount.sh
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/files/drive_mount.sh
@@ -1,5 +1,49 @@
 #!/bin/bash
 
+# The log volume is already mounted by fstab entry on startup
+if mountpoint -q /log; then
+  # Do only chown
+  chown td-agent:td-agent /log
+  exit 0
+fi
+
+# Use root volume if LOG_STORE is not set
+if [[ -z "$LOG_STORE" ]]; then
+  # Create /log directory at the root
+  echo "LOG_STORE is not set: Using Root Volume"
+  mkdir -p /log
+  chown td-agent:td-agent /log
+  exit 0
+fi
+
+mount_log_volume() {
+  name=$1
+  uuid=$2
+
+  echo "Using $NAME as a log volume"
+
+  if [[ -z $uuid ]]; then
+    # The volume is not formatted
+    echo "Running mkfs on $NAME"
+    if mkfs -t xfs $name; then
+      uuid=$(blkid $name -s UUID -o value)
+    else
+      echo "mkfs failed"
+      exit 1
+    fi
+  fi
+
+  if ! grep -q "^UUID=$uuid" /etc/fstab; then
+    echo "Adding fstab entry"
+    echo "UUID=$uuid /log xfs defaults,nofail 0 2" >> /etc/fstab
+  fi
+
+  echo "Mounting $NAME on /log"
+  mkdir -p /log
+  mount /log
+  chown td-agent:td-agent /log
+}
+
 IFS='
 '
 
@@ -11,41 +55,19 @@ for drive in $(lsblk -p -P -d -o name,serial,UUID,HCTL | tail -n +2); do
   # NAME=/dev/nvmeXn1 The name is not consistant between reboots
   eval $drive
 
-  if [[ $UUID == "" ]]; then
-    # Format remote volume and add it to fstab using UUID
-    echo "Remote Volume:" $NAME
-    mkfs -t xfs $NAME
-    if [[ "$?" -ne "0" ]]; then
-      echo "Skip Drive"
-    elif [[ $HCTL == "" ]]; then
-      mkdir -p /mnt/block/$SERIAL
-      echo "UUID="$(blkid $NAME -s UUID -o value)" /mnt/block/$SERIAL xfs defaults,nofail 0 2" >>/etc/fstab
-    else
-      for lun in $(echo $HCTL | tr ":" "\n" | tail -n +4); do
-        echo "Logic Number:" $lun
-        mkdir -p /mnt/block/vol$lun
-        echo "UUID="$(blkid $NAME -s UUID -o value)" /mnt/block/vol$lun xfs defaults,nofail 0 2" >>/etc/fstab
-      done
-    fi
+  echo "Remote Volume: $NAME"
+
+  if [[ -z $HCTL && ${SERIAL#vol} == ${LOG_STORE#vol-} ]]; then
+    # On AWS, LOG_STORE should be set to volume id
+    mount_log_volume $NAME $UUID
+    exit 0
+  elif [[ -n $HCTL && $HCTL == *:$LOG_STORE ]]; then
+    # On Azure, LOG_STORE should be set to lun (the last part of HCTL)
+    mount_log_volume $NAME $UUID
+    exit 0
   fi
 done
 
-# Mount All Drives in fstab
-mount -a
-
-# At this point all volumes have been formatted and mounted
-# Here we will setup the links for the log archive directory
-if [[ -d /mnt/block/vol${LOG_STORE#vol-} ]]; then
-  # Link /log directory to remote volume /mnt/block/vol<ID> directory
-  chown -R td-agent:td-agent /mnt/block/vol${LOG_STORE#vol-}
-  ln -sf /mnt/block/vol${LOG_STORE#vol-} /log
-elif [[ -z "$LOG_STORE" ]]; then
-  # Setup /log directory on root volume
-  echo "LOG_STORE is not set: Using Root Volume"
-  mkdir -p /log
-  chown -R td-agent:td-agent /log
-else
-  # In this case the expected LOG_STORE was not found so we throw an error
-  echo "Cannot find LOG_STORE: $LOG_STORE"
-  exit 1
-fi
+# In this case the expected LOG_STORE was not found so we throw an error
+echo "Cannot find LOG_STORE: $LOG_STORE"
+exit 1

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/files/drive_mount.sh
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/files/drive_mount.sh
@@ -44,11 +44,9 @@ mount_log_volume() {
   chown td-agent:td-agent /log
 }
 
-IFS='
-'
-
 # Loop over the output of lsblk to format volumes
-for drive in $(lsblk -p -P -d -o name,serial,UUID,HCTL | tail -n +2); do
+IFS=$'\n'
+for drive in $(lsblk -p -P -d -o NAME,SERIAL,UUID,HCTL | tail -n +2); do
   # For Each line in lsblk eval the output into the following variable space
   # UUID=<blank if store is not formatted>
   # SERIAL=<either vol-id or AWSxxx> If AWS it indicates local volume

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/files/drive_mount.sh
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/files/drive_mount.sh
@@ -16,15 +16,14 @@ if [[ -z "$LOG_STORE" ]]; then
   exit 0
 fi
 
-mount_log_volume() {
-  name=$1
-  uuid=$2
+mount_log_volume () {
+  local name=$1 uuid=$2
 
-  echo "Using $NAME as a log volume"
+  echo "Using $name as a log volume"
 
   if [[ -z $uuid ]]; then
     # The volume is not formatted
-    echo "Running mkfs on $NAME"
+    echo "Running mkfs on $name"
     if mkfs -t xfs $name; then
       uuid=$(blkid $name -s UUID -o value)
     else
@@ -38,7 +37,7 @@ mount_log_volume() {
     echo "UUID=$uuid /log xfs defaults,nofail 0 2" >> /etc/fstab
   fi
 
-  echo "Mounting $NAME on /log"
+  echo "Mounting $name on /log"
   mkdir -p /log
   mount /log
   chown td-agent:td-agent /log


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-5545

1. Make the external log volume independent of the instance

    The log volume was being deleted when the instance is removed because the availability zone was unknown. This part is changed in the same way as C* nodes.

```
  # module.monitor.aws_ebs_volume.monitor_log_volume[0] must be replaced
-/+ resource "aws_ebs_volume" "monitor_log_volume" {
      ~ arn               = "arn:aws:ec2:us-west-1:825543958249:volume/vol-0259b0b418eadfe33" -> (known after apply)
      ~ availability_zone = "us-west-1b" -> (known after apply) # forces replacement
      ~ encrypted         = false -> (known after apply)
      ~ id                = "vol-0259b0b418eadfe33" -> (known after apply)
      ~ iops              = 0 -> (known after apply)
      + kms_key_id        = (known after apply)
        size              = 500
      + snapshot_id       = (known after apply)
        tags              = {
            "Name"      = "ymtest-i7eqxem Monitor Cluster-1"
            "Network"   = "ymtest-i7eqxem"
            "Owner"     = "yusuke"
            "Terraform" = "true"
        }
        type              = "sc1"
    }
```

2. Update drive_mount script so that it can mount an existing log volume correctly

   The log volume re-attachment was not working because `drive_mount.sh` was not able to handle an external volume that is already formatted. Now it can add an `/etc/fstab` entry correctly even if the volume is not new.
