### PR TITLE
Disable debug.log of Cassandra

### DIFF
--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -133,6 +133,12 @@
     src: cassandra-rackdc.properties.j2
     dest: /etc/cassandra/conf/cassandra-rackdc.properties
 
+- name: Disable debug.log
+  replace:
+    path: /etc/cassandra/conf/logback.xml
+    regexp: '(<appender-ref ref="ASYNCDEBUGLOG"\s*/>)'
+    replace: '<!-- \1 -->'
+
 - name: Delete cassandra-topology.properties
   file:
     path: /etc/cassandra/conf/cassandra-topology.properties

--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -136,7 +136,7 @@
 - name: Disable debug.log
   replace:
     path: /etc/cassandra/conf/logback.xml
-    regexp: '(<appender-ref ref="ASYNCDEBUGLOG"\s*/>)'
+    regexp: '^\s*(<appender-ref ref="ASYNCDEBUGLOG"\s*/>)'
     replace: '<!-- \1 -->'
 
 - name: Delete cassandra-topology.properties


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6294

Stops C* from writing debug.log by updating the logback.xml installed by the cassandra yum package, following the instructions in the file.

```
 <!--
In order to disable debug.log, comment-out the ASYNCDEBUGLOG
appender reference in the root level section below.
-->
```

The changes of llogback.xml are as follows.

```diff
   <root level="INFO">
     <appender-ref ref="SYSTEMLOG" />
     <appender-ref ref="STDOUT" />
-    <appender-ref ref="ASYNCDEBUGLOG" /> <!-- Comment this line to disable debug.log -->
+    <!-- <appender-ref ref="ASYNCDEBUGLOG" /> --> <!-- Comment this line to disable debug.log -->
     <!--
     <appender-ref ref="LogbackMetrics" />
     -->
```