### PR TITLE
Fix contianer restart bug in scalardl

### DIFF
--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -145,7 +145,7 @@ resource "null_resource" "scalardl_schema" {
   count = var.provision_count > 0 ? 1 : 0
 
   triggers = {
-    triggers = null_resource.scalardl_load[0].id
+    triggers = join(",", null_resource.scalardl_load.*.id)
   }
 
   connection {
@@ -168,7 +168,7 @@ resource "null_resource" "scalardl_container" {
   count = var.provision_count
 
   triggers = {
-    triggers = "${null_resource.scalardl_load[count.index].id}${null_resource.scalardl_schema[0].id}"
+    triggers = null_resource.scalardl_load[count.index].id
   }
 
   connection {

--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -145,7 +145,7 @@ resource "null_resource" "scalardl_schema" {
   count = var.provision_count > 0 ? 1 : 0
 
   triggers = {
-    triggers = join(",", null_resource.scalardl_load.*.id)
+    triggers = null_resource.scalardl_load[0].id
   }
 
   connection {
@@ -168,7 +168,7 @@ resource "null_resource" "scalardl_container" {
   count = var.provision_count
 
   triggers = {
-    triggers = null_resource.scalardl_load[count.index].id
+    triggers = "${null_resource.scalardl_load[count.index].id}${null_resource.scalardl_schema[0].id}"
   }
 
   connection {


### PR DESCRIPTION
# Description

- In some cases, image files may not be found under /tmp on the bastion when replacing the instance.
-  Replacing one instance may cause containers in other instances to be restarted.

# Done
- Change the copy destination of the `tar.gz` file from `/tmp` to `~/` from /tm in `bastion`.
- Prevent ansible commands from being executed when recreating image (`docker_install`)