### PR TITLE
Fix td-agent.conf on bastion

### DIFF
--- a/provision/ansible/playbooks/bastion-server.yml
+++ b/provision/ansible/playbooks/bastion-server.yml
@@ -7,7 +7,7 @@
     - role: td-agent
       when: enable_tdagent is undefined or enable_tdagent == '1'
   vars:
-    tdagent_conf_template: templates/cassandra-server/td-agent.conf.j2
+    tdagent_conf_template: templates/bastion-server/td-agent.conf.j2
   gather_facts: no
   become: yes
 


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6466

td-agent.conf for Cassandra hosts is installed on the bastion host.
Only the difference is that td-agent for Cassandra hosts looks at `/var/log/cassandra/system.log`.
