### PR TITLE
td-agent configuration for quicker logging

### DIFF
--- a/provision/ansible/playbooks/files/monitor-server/td-agent.conf
+++ b/provision/ansible/playbooks/files/monitor-server/td-agent.conf
@@ -49,9 +49,9 @@
       timekey 1d
       timekey_wait 5m
       timekey_use_utc true
+      flush_mode immediate
+      flush_thread_count 8
       flush_at_shutdown true
-      flush_mode interval
-      flush_interval 60s
     </buffer>
     <format>
       @type out_file

--- a/provision/ansible/playbooks/templates/bastion-server/td-agent.conf.j2
+++ b/provision/ansible/playbooks/templates/bastion-server/td-agent.conf.j2
@@ -28,4 +28,10 @@
     @type file
     path /var/log/td-agent/forward-failed
   </secondary>
+
+  <buffer>
+    flush_thread_count 8
+    flush_interval 20s
+    chunk_limit_size 8M
+  </buffer>
 </match>

--- a/provision/ansible/playbooks/templates/bastion-server/td-agent.conf.j2
+++ b/provision/ansible/playbooks/templates/bastion-server/td-agent.conf.j2
@@ -30,8 +30,9 @@
   </secondary>
 
   <buffer>
-    flush_thread_count 8
+    flush_mode interval
     flush_interval 20s
+    flush_thread_count 8
     chunk_limit_size 8M
   </buffer>
 </match>

--- a/provision/ansible/playbooks/templates/cassandra-server/td-agent.conf.j2
+++ b/provision/ansible/playbooks/templates/cassandra-server/td-agent.conf.j2
@@ -41,4 +41,10 @@
     @type file
     path /var/log/td-agent/forward-failed
   </secondary>
+
+  <buffer>
+    flush_thread_count 8
+    flush_interval 20s
+    chunk_limit_size 8M
+  </buffer>
 </match>

--- a/provision/ansible/playbooks/templates/cassandra-server/td-agent.conf.j2
+++ b/provision/ansible/playbooks/templates/cassandra-server/td-agent.conf.j2
@@ -43,8 +43,9 @@
   </secondary>
 
   <buffer>
-    flush_thread_count 8
+    flush_mode interval
     flush_interval 20s
+    flush_thread_count 8
     chunk_limit_size 8M
   </buffer>
 </match>

--- a/provision/ansible/playbooks/templates/docker-server/td-agent.conf.j2
+++ b/provision/ansible/playbooks/templates/docker-server/td-agent.conf.j2
@@ -36,8 +36,9 @@
   </secondary>
 
   <buffer>
-    flush_thread_count 8
+    flush_mode interval
     flush_interval 20s
+    flush_thread_count 8
     chunk_limit_size 8M
   </buffer>
 </match>

--- a/provision/ansible/playbooks/templates/docker-server/td-agent.conf.j2
+++ b/provision/ansible/playbooks/templates/docker-server/td-agent.conf.j2
@@ -34,4 +34,10 @@
     @type file
     path /var/log/td-agent/forward-failed
   </secondary>
+
+  <buffer>
+    flush_thread_count 8
+    flush_interval 20s
+    chunk_limit_size 8M
+  </buffer>
 </match>


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6055

Based on the discussion here, updated the configuration to use `flush_mode immediate` on the monitor host, and `flush_interval 20s` on other hosts.
https://github.com/scalar-labs/investigation/tree/master/fluentd
