### PR TITLE
Fix default to use private lb for envoy in azure

### DIFF
--- a/modules/azure/scalardl/envoy.tf
+++ b/modules/azure/scalardl/envoy.tf
@@ -142,7 +142,7 @@ resource "azurerm_lb_probe" "envoy_lb_privileged_probe" {
 }
 
 resource "azurerm_network_interface_backend_address_pool_association" "envoy_lb_association" {
-  count = local.envoy.resource_count
+  count = local.envoy.enable_nlb ? local.envoy.resource_count : 0
 
   network_interface_id    = module.envoy_cluster.network_interface_ids[count.index]
   ip_configuration_name   = "ipconfig${count.index}"

--- a/modules/azure/scalardl/output.tf
+++ b/modules/azure/scalardl/output.tf
@@ -39,7 +39,7 @@ output "scalardl_replication_factor" {
 }
 
 output "envoy_dns" {
-  value       = local.envoy.resource_count > 0 ? azurerm_public_ip.envoy_public_ip.*.fqdn : []
+  value       = local.envoy.enable_nlb ? (local.envoy.nlb_internal ? ["envoy-lb.${local.internal_domain}"] : azurerm_public_ip.envoy_public_ip.*.fqdn) : []
   description = "A list of dns URLs to access a envoy cluster."
 }
 


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-6543

# Done
- Fix default to use private lb for envoy in azure.
- Create public ip only when `nlb_internal` is `true`.
- Add `envoy-lb` dns for private dns.

# Confirm
- When `nlb_internal` = `false`
```
Outputs:

envoy_dns = envoy-tei-envoy-4u1raoq.japaneast.cloudapp.azure.com
```
- When `nlb_internal` = `true`
```
Outputs:

envoy_dns = envoy-lb.internal.scalar-labs.com
```
=>
```
[centos@bastion-1 ~]$ dig +short envoy-lb.internal.scalar-labs.com
10.42.1.7
```