### PR TITLE
Fix get_facts to yes for common role

### DIFF
--- a/provision/ansible/playbooks/cassandra-server.yml
+++ b/provision/ansible/playbooks/cassandra-server.yml
@@ -7,7 +7,7 @@
       when: enable_tdagent is undefined or enable_tdagent == '1'
   vars:
     tdagent_conf_template: templates/cassandra-server/td-agent.conf.j2
-  gather_facts: no
+  gather_facts: yes
   become: yes
 
 - name: Cassandra

--- a/provision/ansible/playbooks/docker-server.yml
+++ b/provision/ansible/playbooks/docker-server.yml
@@ -13,7 +13,7 @@
   hosts: all
   roles:
     - "common"
-  gather_facts: no
+  gather_facts: yes
   become: yes
 
 - name: Docker Server


### PR DESCRIPTION
# Description
```
2020-07-08T15:22:39.5818743Z TestEndToEnd 2020-07-08T15:22:39Z command.go:121: module.cassandra.module.cassandra_provision.null_resource.cassandra[1] (remote-exec): [0;31mfatal: [10.42.2.96]: FAILED! => {"msg": "The conditional check 'ansible_os_family == 'RedHat'' failed. The error was: error while evaluating conditional (ansible_os_family == 'RedHat'): 'ansible_os_family' is undefined\n\nThe error appears to be in '/home/centos/playbooks/roles/common/tasks/setup-redhat.yml': line 2, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n---\n- name: Install epel-release\n  ^ here\n"}[0m
```

# Done
Fix `gather_facts ` to `yes`