### PR TITLE
[WIP] Fix failed pip upgrade in azure

### DIFF
--- a/provision/ansible/playbooks/roles/common/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/common/defaults/main.yml
@@ -5,3 +5,5 @@ pip_packages:
 required_packages:
   - vim
   - lvm2
+
+ansible_python_interpreter: /usr/bin/python

--- a/provision/ansible/playbooks/roles/common/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/common/tasks/main.yml
@@ -5,6 +5,10 @@
 - import_tasks: setup-debian.yml
   when: ansible_os_family == 'Debian'
 
+- set_fact:
+    ansible_python_default_interpreter: "{{ ansible_python_interpreter }}"
+    ansible_python_interpreter: /usr/bin/python3
+
 - name: Upgrade pip
   pip:
     name: pip
@@ -17,6 +21,9 @@
     state: present
     executable: pip3
   loop: "{{ pip_packages }}"
+
+- set_fact:
+    ansible_python_interpreter: "{{ ansible_python_default_interpreter }}"
 
 - name: Install required packages
   package:


### PR DESCRIPTION
# Description
```
2020-07-08T15:17:13.8203301Z TestEndToEnd 2020-07-08T15:17:13Z command.go:121: module.network.module.bastion.module.bastion_provision.null_resource.ansible (local-exec): An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named pkg_resources
2020-07-08T15:17:13.8204734Z TestEndToEnd 2020-07-08T15:17:13Z command.go:121: module.network.module.bastion.module.bastion_provision.null_resource.ansible (local-exec): fatal: [bastion-terratest-5ah5oho.westus.cloudapp.azure.com]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (setuptools) on bastion-1's Python /usr/bin/python. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```

# Done
Fix to use python3 for ansible_python_interpreter around pip install. (workaround)