### PR TITLE
Add python-setuptools for upgrade pip3

### DIFF
--- a/provision/ansible/playbooks/roles/common/tasks/setup-debian.yml
+++ b/provision/ansible/playbooks/roles/common/tasks/setup-debian.yml
@@ -7,3 +7,4 @@
     packages:
       - python3
       - python3-pip
+      - python-setuptools

--- a/provision/ansible/playbooks/roles/common/tasks/setup-redhat.yml
+++ b/provision/ansible/playbooks/roles/common/tasks/setup-redhat.yml
@@ -12,3 +12,4 @@
     packages:
       - python3
       - python3-pip
+      - python-setuptools


### PR DESCRIPTION
# Description

#160 another workaround.

```
2020-07-09T15:15:25.0378046Z TestEndToEnd 2020-07-09T15:15:25Z command.go:121: module.network.module.bastion.module.bastion_provision.null_resource.ansible (local-exec): An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named pkg_resources
2020-07-09T15:15:25.0380714Z TestEndToEnd 2020-07-09T15:15:25Z command.go:121: module.network.module.bastion.module.bastion_provision.null_resource.ansible (local-exec): fatal: [bastion-terratest-clgg6o0.westus.cloudapp.azure.com]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (setuptools) on bastion-1's Python /usr/bin/python. Please read module documentation and install in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}
```

# Done
Add `python-setuptools` for pip module

# Refs
https://github.com/ansible/ansible/issues/47361