### PR TITLE
Create /etc/prometheus directory for cassandra_exporter

### DIFF
--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -153,6 +153,10 @@
 
 - name: Install Tools
   block:
+    - file:
+        path: "/etc/prometheus"
+        state: directory
+        mode: 0755
     - get_url:
         url: https://github.com/criteo/cassandra_exporter/releases/download/2.1.0/cassandra_exporter-2.1.0-all.jar
         dest: /etc/prometheus/cassandra_exporter.jar


### PR DESCRIPTION
After [this change](https://github.com/scalar-labs/scalar-terraform/pull/158/files#diff-4165298561f1b7c66eb5032890d539a9L33-L36
) in #158 was merged, downloading Cassandra exporter began to fail with the following error saying that the `/etc/prometheus` directory does not exist.

```
module.cassandra.module.cassandra_provision.null_resource.cassandra[0] (remote-exec): fatal: [10.42.2.46]: FAILED! => {"changed": false, "checksum_dest": null, "checksum_src": "a69640dece0763de9121d1fe0743af1ab455666c", "dest": "/etc/prometheus/cassandra_exporter.jar", "elapsed": 1, "msg": "Destination /etc/prometheus does not exist", "src": "/home/centos/.ansible/tmp/ansible-tmp-1594691082.2689898-29204-260219100449879/tmp16_z8N", "url": "https://github.com/criteo/cassandra_exporter/releases/download/2.1.0/cassandra_exporter-2.1.0-all.jar"}
```
