### PR TITLE
Add resource_group_name to Azure remote backend config examples

### DIFF
--- a/examples/azure/ca/remote.tf.azurerm
+++ b/examples/azure/ca/remote.tf.azurerm
@@ -2,9 +2,9 @@ data "terraform_remote_state" "network" {
   backend = "azurerm"
 
   config = {
+    resource_group_name  = "example-tfstate"
     storage_account_name = "exampletfstate"
     container_name       = "tfstate"
     key                  = "network/terraform.tfstate"
-
   }
 }

--- a/examples/azure/cassandra/remote.tf.azurerm
+++ b/examples/azure/cassandra/remote.tf.azurerm
@@ -2,9 +2,9 @@ data "terraform_remote_state" "network" {
   backend = "azurerm"
 
   config = {
+    resource_group_name  = "example-tfstate"
     storage_account_name = "exampletfstate"
     container_name       = "tfstate"
     key                  = "network/terraform.tfstate"
-
   }
 }

--- a/examples/azure/monitor/remote.tf.azurerm
+++ b/examples/azure/monitor/remote.tf.azurerm
@@ -2,6 +2,7 @@ data "terraform_remote_state" "network" {
   backend = "azurerm"
 
   config = {
+    resource_group_name  = "example-tfstate"
     storage_account_name = "exampletfstate"
     container_name       = "tfstate"
     key                  = "network/terraform.tfstate"
@@ -15,10 +16,10 @@ data "terraform_remote_state" "cassandra" {
   backend = "azurerm"
 
   config = {
+    resource_group_name  = "example-tfstate"
     storage_account_name = "exampletfstate"
     container_name       = "tfstate"
     key                  = "cassandra/terraform.tfstate"
-
   }
 }
 
@@ -28,9 +29,9 @@ data "terraform_remote_state" "scalardl" {
   backend = "azurerm"
 
   config = {
+    resource_group_name  = "example-tfstate"
     storage_account_name = "exampletfstate"
     container_name       = "tfstate"
     key                  = "scalardl/terraform.tfstate"
-
   }
 }

--- a/examples/azure/scalardl/remote.tf.azurerm
+++ b/examples/azure/scalardl/remote.tf.azurerm
@@ -2,10 +2,10 @@ data "terraform_remote_state" "network" {
   backend = "azurerm"
 
   config = {
+    resource_group_name  = "example-tfstate"
     storage_account_name = "exampletfstate"
     container_name       = "tfstate"
     key                  = "network/terraform.tfstate"
-
   }
 }
 
@@ -13,9 +13,9 @@ data "terraform_remote_state" "cassandra" {
   backend = "azurerm"
 
   config = {
+    resource_group_name  = "example-tfstate"
     storage_account_name = "exampletfstate"
     container_name       = "tfstate"
     key                  = "cassandra/terraform.tfstate"
-
   }
 }


### PR DESCRIPTION
Add the resource group name to Azure remote backend config examples, as the following error occurs without this.

`Error: Either an Access Key / SAS Token or the Resource Group for the Storage Account must be specified`

The resource group name `example-tfstate` is the same as the one specified in the backend example.
https://github.com/scalar-labs/scalar-terraform/blob/b765af5/examples/azure/network/backend.tf.azurerm#L3