### PR TITLE
Associate AWS IAM role with Cassy instance for uploading metadata backup

### DIFF
--- a/modules/aws/cassandra/cassy.tf
+++ b/modules/aws/cassandra/cassy.tf
@@ -12,6 +12,7 @@ module "cassy_cluster" {
   subnet_ids                  = local.subnet_ids
   associate_public_ip_address = false
   hostname_prefix             = "cassy"
+  iam_instance_profile        = aws_iam_instance_profile.cassandra.name
   use_num_suffix              = true
 
   tags = merge(


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6781

Addresses an issue where Cassy metadata cannot be uploaded to S3.