### PR TITLE
Refactoring td agent buffer

### DIFF
--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-bastion.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-bastion.conf.j2
@@ -7,7 +7,7 @@
 <filter **>
   @type record_transformer
   <record>
-    hostname ${hostname}
+    hostname "#{Socket.gethostname}"
   </record>
 </filter>
 

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
@@ -20,7 +20,7 @@
 <filter **>
   @type record_transformer
   <record>
-    hostname ${hostname}
+    hostname "#{Socket.gethostname}"
   </record>
 </filter>
 

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-docker.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-docker.conf.j2
@@ -13,7 +13,7 @@
 <filter **>
   @type record_transformer
   <record>
-    hostname ${hostname}
+    hostname "#{Socket.gethostname}"
   </record>
 </filter>
 

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
@@ -21,6 +21,7 @@
 </source>
 
 # Capture fluentd's own logs
+
 <match fluent.**>
   @type relabel
   @label @local
@@ -31,7 +32,7 @@
   <filter **>
     @type record_transformer
     <record>
-      hostname ${hostname}
+      hostname "#{Socket.gethostname}"
     </record>
   </filter>
   <match **>
@@ -46,6 +47,8 @@
     path /log/${hostname}/%Y/%m-%d/${tag[0]}
     append true
     <buffer time,tag,hostname>
+      @type file
+      path /log/buffer
       timekey 1d
       timekey_wait 5m
       timekey_use_utc true

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
@@ -21,11 +21,12 @@
 </source>
 
 # Capture fluentd's own logs
-
-<match fluent.**>
-  @type relabel
-  @label @local
-</match>
+<label @FLUENT_LOG>
+  <match fluent.**>
+    @type relabel
+    @label @local
+  </match>
+</label>
 
 # Add hostname field to local log records
 <label @local>


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-6787

# Done
- Fix buffer path instead of `${hostname}/%Y/%m-%d/`
```
[root@monitor-1 buffer]# ll /log
total 0
drwxr-xr-x. 3 td-agent td-agent 18 Jul 27 05:40 bastion-1
drwxr-xr-x. 2 td-agent td-agent  6 Jul 27 08:17 buffer
drwxr-xr-x. 3 td-agent td-agent 18 Jul 27 06:30 cassandra-1
drwxr-xr-x. 3 td-agent td-agent 18 Jul 27 06:30 cassandra-2
drwxr-xr-x. 3 td-agent td-agent 18 Jul 27 05:02 cassandra-3
drwxr-xr-x. 3 td-agent td-agent 18 Jul 27 04:53 monitor-1
```
- Fix warning
https://docs.fluentd.org/deployment/logging#capture-fluentd-logs
```
2020-07-27 07:53:22 +0000 [warn]: #0 define <match fluent.**> to capture fluentd logs in top level is deprecated. Use <label @FLUENT_LOG> instead
```
- Fix to use `#{Socket.gethostname}`
https://docs.fluentd.org/filter/record_transformer