### PR TITLE
Fix create schema failure for reaper

### DIFF
--- a/modules/universal/reaper/provision/docker-compose.yml
+++ b/modules/universal/reaper/provision/docker-compose.yml
@@ -1,17 +1,17 @@
-version: '3.7'
+version: "3.7"
 services:
   cqlsh:
     image: scalar-cassandra-reaper:latest
     build:
       context: ./
     command:
-     - "cqlsh"
-     - "--cqlversion=3.4.4"
-     - "--username=${REAPER_CASS_AUTH_USERNAME}"
-     - "--password=${REAPER_CASS_AUTH_PASSWORD}"
-     - "--execute"
-     - "CREATE KEYSPACE IF NOT EXISTS reaper_db WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': ${CASSANDRA_REPLICATION_FACTOR} };"
-     - "${REAPER_CASS_CONTACT_POINTS}"
+      - "cqlsh"
+      - "--cqlversion=3.4.4"
+      - "--username=${REAPER_CASS_AUTH_USERNAME}"
+      - "--password=${REAPER_CASS_AUTH_PASSWORD}"
+      - "--execute"
+      - "CREATE KEYSPACE IF NOT EXISTS reaper_db WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ${CASSANDRA_REPLICATION_FACTOR} };"
+      - "${REAPER_CASS_CONTACT_POINTS}"
     restart: on-failure
   reaper:
     image: scalar-cassandra-reaper:latest


### PR DESCRIPTION
# Description
Failed in create schema, because `replication_factor` is an option for SimpleStrategy.
```
2020-08-13T08:40:37+00:00       docker.provision_cqlsh_1        {"source":"stderr","log":"<stdin>:1:ConfigurationException: <Error from server: code=2300 [Query inv
alid because of configuration issue] message=\"replication_factor is an option for SimpleStrategy, not NetworkTopologyStrategy\">","container_id":"a49dd6e8bdba380fc
817d615063bd05bf546f4eb96fad3835cb0e14631e23fce","container_name":"/provision_cqlsh_1","hostname":"reaper-1"}
```

# Done
Fix to use `dc1`