### PR TITLE
New environment variable added in scalardl env file

### DIFF
--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -218,6 +218,8 @@ resource "null_resource" "scalardl_container" {
       "echo export SCALAR_CASSANDRA_HOST=${local.scalar_cassandra_host} >> env",
       "echo export SCALAR_CASSANDRA_USERNAME=${var.cassandra_username} >> env",
       "echo export SCALAR_CASSANDRA_PASSWORD=${var.cassandra_password} >> env",
+      "echo export SCHEMA_LOADER_CASSANDRA_IMAGE=${local.schema_loader_cassandra_image} >> env",
+      "echo export CASSANDRA_REPLICATION_FACTOR=${var.replication_factor} >> env",
       "source ./env",
       "docker-compose up -d",
     ]


### PR DESCRIPTION
New environment variables added in scalardl `env` file for creating schema manually using `scalardl-schema-loader-cassandra` image.

```
docker run -e CASSANDRA_HOST=${SCALAR_CASSANDRA_HOST} -e CASSANDRA_USERNAME=${SCALAR_CASSANDRA_USERNAME} -e CASSANDRA_PASSWORD=${SCALAR_CASSANDRA_PASSWORD} -e CASSANDRA_REPLICATION_FACTOR=${CASSANDRA_REPLICATION_FACTOR} --rm ${SCHEMA_LOADER_CASSANDRA_IMAGE}
```
Modification based on the review comments
https://github.com/scalar-labs/misc/pull/9#discussion_r474422508