### PR TITLE
Add logrotate for monitor

### DIFF
--- a/examples/aws/monitor/example.tfvars
+++ b/examples/aws/monitor/example.tfvars
@@ -12,6 +12,7 @@ monitor = {
   # log_volume_size           = "500"
   # log_volume_type           = "sc1"
   # enable_tdagent            = "true"
+  # log_retention_period_days = "30"
 }
 
 # targets = [

--- a/examples/azure/monitor/example.tfvars
+++ b/examples/azure/monitor/example.tfvars
@@ -12,6 +12,7 @@ monitor = {
   # set_public_access             = "false"
   # remote_port                   = 9090
   # enable_accelerated_networking = "false"
+  # log_retention_period_days     = "30"
 }
 
 # targets = [

--- a/modules/aws/monitor/locals.tf
+++ b/modules/aws/monitor/locals.tf
@@ -32,6 +32,7 @@ locals {
     log_volume_size           = 500
     log_volume_type           = "sc1"
     enable_tdagent            = true
+    log_retention_period_days = 30
   }
 }
 

--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -113,6 +113,7 @@ module "monitor_provision" {
   enable_tdagent                = local.monitor.enable_tdagent
   internal_domain               = local.internal_domain
   targets                       = var.targets
+  log_retention_period_days     = local.monitor.log_retention_period_days
 }
 
 resource "aws_security_group" "monitor" {

--- a/modules/azure/monitor/locals.tf
+++ b/modules/azure/monitor/locals.tf
@@ -35,6 +35,7 @@ locals {
     set_public_access             = false
     remote_port                   = 9090
     enable_accelerated_networking = false
+    log_retention_period_days     = 30
   }
 }
 

--- a/modules/azure/monitor/main.tf
+++ b/modules/azure/monitor/main.tf
@@ -92,6 +92,7 @@ module "monitor_provision" {
   enable_tdagent                = local.monitor.enable_tdagent
   internal_domain               = local.internal_domain
   targets                       = var.targets
+  log_retention_period_days     = local.monitor.log_retention_period_days
 }
 
 resource "azurerm_private_dns_a_record" "monitor_cluster_dns" {

--- a/modules/universal/monitor/main.tf
+++ b/modules/universal/monitor/main.tf
@@ -43,7 +43,7 @@ resource "null_resource" "docker_install" {
   provisioner "remote-exec" {
     inline = [
       "cd ${module.ansible.remote_playbook_path}/playbooks",
-      "ansible-playbook -u ${var.user_name} -i ${var.host_list[count.index]}, monitor-server.yml --extra-vars='enable_tdagent=${var.enable_tdagent ? 1 : 0}'",
+      "ansible-playbook -u ${var.user_name} -i ${var.host_list[count.index]}, monitor-server.yml -e enable_tdagent=${var.enable_tdagent ? 1 : 0} -e log_retention_period_days=${var.log_retention_period_days}",
     ]
   }
 }

--- a/modules/universal/monitor/vars.tf
+++ b/modules/universal/monitor/vars.tf
@@ -65,3 +65,8 @@ variable "targets" {
   default     = []
   description = "A list of targets to be monitored"
 }
+
+variable "log_retention_period_days" {
+  default     = 30
+  description = "Set the retention period of the aggregated log to the monitor server"
+}

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
@@ -17,3 +17,11 @@
     enabled: yes
     daemon_reload: yes
     state: started
+
+- name: Setup logrotate.d
+  template:
+    src: monitor.logrotate.j2
+    dest: /etc/logrotate.d/monitor
+    mode: 0644
+    owner: root
+    group: root

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/templates/monitor.logrotate.j2
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/templates/monitor.logrotate.j2
@@ -1,0 +1,9 @@
+/log/**/*.log
+{
+  daily
+  rotate {{ log_retention_period_days }}
+  missingok
+  compress
+  dateext
+  create 644 td-agent td-agent
+}

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
@@ -45,14 +45,11 @@
 <label @store>
   <match **>
     @type file
-    path /log/${hostname}/%Y/%m-%d/${tag[0]}
+    path /log/${hostname}/${tag[0]}
     append true
-    <buffer time,tag,hostname>
+    <buffer tag,hostname>
       @type file
       path /log/buffer
-      timekey 1d
-      timekey_wait 5m
-      timekey_use_utc true
       flush_mode immediate
       flush_thread_count 8
       flush_at_shutdown true


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7005

# Done
- Add logrotate.d config file to `td-agent_aggregation` role.
- Change output path for aggregated logs.
/log/${hostname}/YYYY/MM/DD/xxx.log -> /log/${hostname}/xxx.log
- Daily rotate by `logrotate` cmd.
e.g.
```
[root@monitor-1 scalardl-blue-1]# ll /log/scalardl-blue-1/
total 12
-rw-r--r--. 1 td-agent td-agent   0 Aug 27 06:15 fluent.log
-rw-r--r--. 1 td-agent td-agent 623 Aug 27 05:43 fluent.log-20200827.gz
-rw-r--r--. 1 td-agent td-agent 671 Aug 27 06:20 system.log
-rw-r--r--. 1 td-agent td-agent 645 Aug 27 06:10 system.log-20200827.gz
```