### PR TITLE
Modification related to EBS data volume replacement

### DIFF
--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -128,7 +128,7 @@ You need to modify the file `/etc/cassandra/conf/cassandra-env.sh` to add the li
 JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address_first_boot=<dead_node_ip>"
 ```
 
-You also need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you relaced a seed node and a volume.
+You also need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you replaced a seed node and a volume.
 * Remove the newly created Cassandra node IP from the seeds of the node.
 
 Finally you can start the Cassandra service.
@@ -137,9 +137,7 @@ Finally you can start the Cassandra service.
 sudo systemctl start cassandra
 ```
 
-* After a successful restart of the newly created Cassandra node, you should replace the seeds of all Cassandra nodes with newly created Cassandra node IP and restart the Cassandra nodes.
-```console
-```
+If you replaced a seed node, you should replace the seeds of all Cassandra nodes with newly created Cassandra node IP.
 
 # Related Documents
 

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -128,11 +128,16 @@ You need to modify the file `/etc/cassandra/conf/cassandra-env.sh` to add the li
 JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address_first_boot=<dead_node_ip>"
 ```
 
+* You need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you chose *Taint Volume*
+  * Remove the newly created cassandra node IP from the newly created cassandra node seeds.
+
 * Finally you can start the Cassandra service.
 
 ```console
 sudo systemctl start cassandra
 ```
+
+* After a successful restart of the newly created Cassandra node, you should replace the seeds of all Cassandra nodes with newly created Cassandra node IP.
 
 # Related Documents
 

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -129,7 +129,7 @@ JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address_first_boot=<dead_node_ip>"
 ```
 
 You also need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you relaced a seed node and a volume.
-  * Remove the newly created cassandra node IP from the newly created cassandra node seeds.
+* Remove the newly created Cassandra node IP from the seeds of the node.
 
 * Finally you can start the Cassandra service.
 

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -128,7 +128,7 @@ You need to modify the file `/etc/cassandra/conf/cassandra-env.sh` to add the li
 JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address_first_boot=<dead_node_ip>"
 ```
 
-* You need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you choose *Taint Volume*
+You also need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you relaced a seed node and a volume.
   * Remove the newly created cassandra node IP from the newly created cassandra node seeds.
 
 * Finally you can start the Cassandra service.

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -137,7 +137,7 @@ Finally you can start the Cassandra service.
 sudo systemctl start cassandra
 ```
 
-If you replaced a seed node, you should replace the seeds of all Cassandra nodes with newly created Cassandra node IP.
+If you replaced a seed node (old seed node), you should replace the old seed node's IP of all Cassandra nodes with newly created Cassandra node IP.
 
 # Related Documents
 

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -139,7 +139,6 @@ sudo systemctl start cassandra
 
 * After a successful restart of the newly created Cassandra node, you should replace the seeds of all Cassandra nodes with newly created Cassandra node IP and restart the Cassandra nodes.
 ```console
-sudo systemctl restart cassandra
 ```
 
 # Related Documents

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -128,7 +128,7 @@ You need to modify the file `/etc/cassandra/conf/cassandra-env.sh` to add the li
 JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address_first_boot=<dead_node_ip>"
 ```
 
-* You need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you chose *Taint Volume*
+* You need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you choose *Taint Volume*
   * Remove the newly created cassandra node IP from the newly created cassandra node seeds.
 
 * Finally you can start the Cassandra service.

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -137,7 +137,10 @@ JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address_first_boot=<dead_node_ip>"
 sudo systemctl start cassandra
 ```
 
-* After a successful restart of the newly created Cassandra node, you should replace the seeds of all Cassandra nodes with newly created Cassandra node IP.
+* After a successful restart of the newly created Cassandra node, you should replace the seeds of all Cassandra nodes with newly created Cassandra node IP and restart the Cassandra nodes.
+```console
+sudo systemctl restart cassandra
+```
 
 # Related Documents
 

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -131,7 +131,7 @@ JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address_first_boot=<dead_node_ip>"
 You also need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you relaced a seed node and a volume.
 * Remove the newly created Cassandra node IP from the seeds of the node.
 
-* Finally you can start the Cassandra service.
+Finally you can start the Cassandra service.
 
 ```console
 sudo systemctl start cassandra

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -128,7 +128,7 @@ You need to modify the file `/etc/cassandra/conf/cassandra-env.sh` to add the li
 JVM_OPTS="$JVM_OPTS -Dcassandra.replace_address_first_boot=<dead_node_ip>"
 ```
 
-You also need to modify the file `/etc/cassandra/conf/cassandra.yaml` If you replaced a seed node and a volume.
+You also need to modify the file `/etc/cassandra/conf/cassandra.yaml` if you replaced a seed node and a volume.
 * Remove the newly created Cassandra node IP from the seeds of the node.
 
 Finally you can start the Cassandra service.


### PR DESCRIPTION
Cassandra node replacement doc updated for EBS data volume crash recovery.

- Cassandra node replacement with taint volume (Need to remove newly created node IP from seeds before restarting the new node).

- Replace the seeds of all Cassandra nodes after Cassandra node replacement(Replace newly created node IP).