### PR TITLE
Azure node replacement document modification

### DIFF
--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -66,7 +66,8 @@ terraform show | grep module.cassandra
 When you taint the volume attachment terraform will try to attach the same data or commit log volume to the new instance. This is the ideal situation as it is the quickest way to replace a node.
 
 ##### Azure
-If crashed node is available in resource group
+If the crashed node is listed in the resource group
+
 ```console
 terraform taint "module.cassandra.module.cassandra_cluster.azurerm_virtual_machine.vm-linux[0]"
 terraform taint "module.cassandra.azurerm_virtual_machine_data_disk_attachment.cassandra_data_volume_attachment[0]"
@@ -74,7 +75,7 @@ terraform taint "module.cassandra.azurerm_virtual_machine_data_disk_attachment.c
 terraform apply
 ```
 
-If crashed node is not available in resource group.
+If the crashed node is not listed in the resource group
 
 * Remove os-disk of crashed node If it is available.
 

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -74,7 +74,7 @@ terraform taint "module.cassandra.azurerm_virtual_machine_data_disk_attachment.c
 terraform apply
 ```
 
-If you face an error or accidentally terminated the node, please try the following.
+If you face an error or accidentally terminated the node or deleted the OS disk manually, please try the following.
 * Remove an OS disk if attached to the node.
 * Do `terraform state rm` as follows.
 

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -66,12 +66,25 @@ terraform show | grep module.cassandra
 When you taint the volume attachment terraform will try to attach the same data or commit log volume to the new instance. This is the ideal situation as it is the quickest way to replace a node.
 
 ##### Azure
+If crashed node is available in resource group
 ```console
 terraform taint "module.cassandra.module.cassandra_cluster.azurerm_virtual_machine.vm-linux[0]"
 terraform taint "module.cassandra.azurerm_virtual_machine_data_disk_attachment.cassandra_data_volume_attachment[0]"
 
 terraform apply
 ```
+
+If crashed node is not available in resource group.
+
+* Remove os-disk of crashed node If it is available.
+
+```console
+terraform state rm module.cassandra.module.cassandra_cluster.azurerm_virtual_machine.vm-linux[0]
+terraform state rm module.cassandra.azurerm_virtual_machine_data_disk_attachment.cassandra_data_volume_attachment[0]
+
+terraform apply
+```
+
 ##### AWS
 ```console
 terraform taint "module.cassandra.module.cassandra_cluster.aws_instance.this[0]"

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -75,7 +75,7 @@ terraform apply
 ```
 
 If you face an error or accidentally terminated the node or deleted the OS disk manually, please try the following.
-* Remove an OS disk if attached to the node.
+* Terminate the node and remove the OS disk if it is attached to the node.
 * Do `terraform state rm` as follows.
 
 

--- a/docs/NodeReplacement.md
+++ b/docs/NodeReplacement.md
@@ -9,7 +9,7 @@ The process of replacement is as follows.
 1. `terraform taint` for a node instance resource
 2. `terraform apply`
 
-For Azure, Remove the os-disk of the crashed node If os-disk is available without the crashed node in the resource group.
+For Azure, You will need to remove os-disk of terminated node when the node is terminated accidentally.
 
 Note that when tainting a resource, you need to go to the directory where the resource was created. The second part of the resource name represents the module name. For example, if you need to taint a resource `module.scalardl.module.foo.aws_instance.this[0]`, you need to go to `scalardl` directory first.
 

--- a/docs/NodeReplacement.md
+++ b/docs/NodeReplacement.md
@@ -6,8 +6,10 @@ You will need to do a combination of taint and apply commands. It destroys and r
 
 The process of replacement is as follows.
 
-1. `terraform taint` for a node intance resource
+1. `terraform taint` for a node instance resource
 2. `terraform apply`
+
+For Azure, Remove the os-disk of the crashed node If os-disk is available without the crashed node in the resource group.
 
 Note that when tainting a resource, you need to go to the directory where the resource was created. The second part of the resource name represents the module name. For example, if you need to taint a resource `module.scalardl.module.foo.aws_instance.this[0]`, you need to go to `scalardl` directory first.
 

--- a/docs/NodeReplacement.md
+++ b/docs/NodeReplacement.md
@@ -9,7 +9,7 @@ The process of replacement is as follows.
 1. `terraform taint` for a node instance resource
 2. `terraform apply`
 
-For Azure, You will need to remove os-disk of terminated node when the node is terminated accidentally.
+For Azure, Remove the os-disk of accidentally terminated node before executing `terraform apply` 
 
 Note that when tainting a resource, you need to go to the directory where the resource was created. The second part of the resource name represents the module name. For example, if you need to taint a resource `module.scalardl.module.foo.aws_instance.this[0]`, you need to go to `scalardl` directory first.
 


### PR DESCRIPTION
If crashed Cassandra node is not available in the Azure resource group we need to use the `terraform state rm` command instead of `terraform taint`.

For Azure, Remove the os-disk of the crashed node If os-disk is available without the crashed node in the resource group.