### PR TITLE
Fix non-bash error

### DIFF
--- a/modules/universal/bastion/main.tf
+++ b/modules/universal/bastion/main.tf
@@ -19,7 +19,7 @@ resource "null_resource" "ansible_playbooks_copy" {
     command = <<EOT
 # add addtional public keys to tmp file
 rm -f ${module.ansible.local_playbook_path}/files/ssh/additional_public_keys
-if [[ -s "${var.additional_public_keys_path}" ]]; then
+if [ -s "${var.additional_public_keys_path}" ]; then
   cp ${var.additional_public_keys_path} ${module.ansible.local_playbook_path}/files/ssh/additional_public_keys
 fi;
   EOT


### PR DESCRIPTION
# Description

Terratest log in github actions.
```
module.network.module.bastion.module.bastion_provision.null_resource.ansible_playbooks_copy[0]: Provisioning with 'local-exec'...
2020-09-07T15:18:09.7309870Z TestEndToEnd 2020-09-07T15:18:09Z command.go:121: module.network.module.bastion.module.bastion_provision.null_resource.ansible_playbooks_copy[0] (local-exec): Executing: ["/bin/sh" "-c" "# add addtional public keys to tmp file\nrm -f ../../../../provision/ansible/playbooks/files/ssh/additional_public_keys\nif [[ -s \"./additional_public_keys\" ]]; then\n  cp ./additional_public_keys ../../../../provision/ansible/playbooks/files/ssh/additional_public_keys\nfi;\n"]
2020-09-07T15:18:09.7339864Z TestEndToEnd 2020-09-07T15:18:09Z command.go:121: module.network.module.bastion.module.bastion_provision.null_resource.ansible_playbooks_copy[0] (local-exec): /bin/sh: 3: [[: not found
2020-09-07T15:18:09.7341556Z TestEndToEnd 2020-09-07T15:18:09Z command.go:121: module.network.module.bastion.module.bastion_provision.null_resource.ansible_playbooks_copy[0]: Provisioning with 'file'...
2020-09-07T15:18:14.9284088Z TestEndToEnd 2020-09-07T15:18:14Z command.go:121: 
```

reason:
The platform is using  ubuntu with dash, it does not support `[[`.

# Done
Fix to use `[ condition ]`.