### PR TITLE
Add resource type to triggers for update cassandra configurations

### DIFF
--- a/modules/aws/cassandra/cassandra.tf
+++ b/modules/aws/cassandra/cassandra.tf
@@ -188,7 +188,7 @@ resource "null_resource" "volume_commitlog_local" {
 module "cassandra_provision" {
   source                = "../../universal/cassandra"
   vm_ids                = module.cassandra_cluster.id
-  triggers              = local.triggers
+  triggers              = concat(local.triggers, [local.cassandra.resource_type])
   bastion_host_ip       = local.bastion_ip
   host_list             = module.cassandra_cluster.private_ip
   host_seed_list        = local.cassandra.resource_count > 0 ? slice(module.cassandra_cluster.private_ip, 0, min(local.cassandra.resource_count, 3)) : []

--- a/modules/azure/cassandra/cassandra.tf
+++ b/modules/azure/cassandra/cassandra.tf
@@ -156,7 +156,7 @@ resource "null_resource" "volume_commitlog_local" {
 
 module "cassandra_provision" {
   source                = "../../universal/cassandra"
-  triggers              = local.triggers
+  triggers              = concat(local.triggers, [local.cassandra.resource_type])
   vm_ids                = module.cassandra_cluster.vm_ids
   bastion_host_ip       = local.bastion_ip
   host_list             = module.cassandra_cluster.network_interface_private_ip


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7192

📝 vm_ids are not changed when the resource type was changed.

# Done
- Add resource type to triggers for update Cassandra configuration when change resource type.