### PR TITLE
Fix to support nvme in tuned

### DIFF
--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -4,11 +4,11 @@ tuned_profile: virtual-guest
 # In AWS, sda and xvda are used depending on virtualization types.
 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html#available-ec2-device-names
 # In Azure, sda is used for OS.
-tuned_disk_devices: '!sda, !xvda'
+tuned_disk_devices: "!sda, !xvda, !nvme0n1"
 disk_read_ahead: 8
 CASSANDRA_MEMTABLE_THRESHOLD: 0.33
 CASSANDRA_STATE: stopped
 cassandra_dc_id: dc1
 cassandra_rack_id: rack1
 endpoint_snitch: GossipingPropertyFileSnitch
-vm_max_map_count: '1048575'
+vm_max_map_count: "1048575"

--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -11,4 +11,4 @@ CASSANDRA_STATE: stopped
 cassandra_dc_id: dc1
 cassandra_rack_id: rack1
 endpoint_snitch: GossipingPropertyFileSnitch
-vm_max_map_count: "1048575"
+vm_max_map_count: 1048575

--- a/provision/ansible/playbooks/roles/cassandra/handlers/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/handlers/main.yml
@@ -3,3 +3,8 @@
   systemd:
     name: cassandra
     state: restarted
+
+- name: restart tuned
+  systemd:
+    name: tuned
+    state: restarted

--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -21,6 +21,12 @@
     path: /etc/tuned/cassandra
     state: directory
 
+- name: Replace plugin_disk.py of tuned for support nvme disk
+  replace:
+    path: /usr/lib/python2.7/site-packages/tuned/plugins/plugin_disk.py
+    regexp: '^(\s*device.parent.subsystem in \["scsi", "virtio", "xen")\]\)$'
+    replace: '\1, "nvme"])'
+
 - name: Add Cassandra Tuned Profile
   template:
     src: tuned.conf.j2

--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -21,6 +21,8 @@
     path: /etc/tuned/cassandra
     state: directory
 
+# Tuned does not yet support nvme disk
+# https://github.com/redhat-performance/tuned/issues/101
 - name: Replace plugin_disk.py of tuned for support nvme disk
   replace:
     path: /usr/lib/python2.7/site-packages/tuned/plugins/plugin_disk.py

--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -26,6 +26,7 @@
     path: /usr/lib/python2.7/site-packages/tuned/plugins/plugin_disk.py
     regexp: '^(\s*device.parent.subsystem in \["scsi", "virtio", "xen")\]\)$'
     replace: '\1, "nvme"])'
+  notify: restart tuned
 
 - name: Add Cassandra Tuned Profile
   template:

--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -23,7 +23,7 @@
 
 # Tuned does not yet support nvme disk
 # https://github.com/redhat-performance/tuned/issues/101
-- name: Replace plugin_disk.py of tuned for support nvme disk
+- name: Replace plugin_disk.py of tuned for supporting nvme disk
   replace:
     path: /usr/lib/python2.7/site-packages/tuned/plugins/plugin_disk.py
     regexp: '^(\s*device.parent.subsystem in \["scsi", "virtio", "xen")\]\)$'


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7210

`Tuned` does not yet support `nvme`
https://github.com/redhat-performance/tuned/issues/101

# Done
- Replace `plugin_disk.py` for support nvme disk.
- If the `plugin_disk.py` file does not exist, ansible will fail. (Making it easier to notice anomalies by not confirming the existence of the file)
```
module.cassandra.module.cassandra_provision.null_resource.cassandra[2] (remote-exec): fatal: [10.42.2.175]: FAILED! => {"changed": false, "msg": "Path /usr/lib/python2.7/site-packages/tuned/plugins/plugin_disk.py does not exist !", "rc": 257}
```
- Except `nvme0n1`.