### PR TITLE
Specify cqlversion to 3.4.4 for create cassandra schema

### DIFF
--- a/modules/universal/scalardl/provision/create_schema.sh
+++ b/modules/universal/scalardl/provision/create_schema.sh
@@ -3,4 +3,5 @@
 cqlsh -u "${SCALAR_DB_USERNAME}" \
       -p "${SCALAR_DB_PASSWORD}" \
       -f ./create_schema.cql \
+      --cqlversion=3.4.4 \
       "${SCALAR_DB_CONTACT_POINTS}" "${SCALAR_DB_CONTACT_PORT}"


### PR DESCRIPTION
# Description
```
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_schema[0] (remote-exec): Connection error: ('Unable to connect to any servers', {'10.42.2.6': ProtocolError("cql_version '3.3.1' is not supported by remote (w/ native protocol). Supported versio
ns: [u'3.4.4']",), '10.42.2.4': ProtocolError("cql_version '3.3.1' is not supported by remote (w/ native protocol). Supported versions: [u'3
.4.4']",), '10.42.2.5': ProtocolError("cql_version '3.3.1' is not supported by remote (w/ native protocol). Supported versions: [u'3.4.4']",
)})
```

# Done
Add `--cqlversion=3.4.4` option for `cqlsh` in `create_schema.sh`.

# After merge
Create new tag `1.3.2` from branch `1.3`