### PR TITLE
Configurable data retention for prometheus

### DIFF
--- a/examples/aws/monitor/example.tfvars
+++ b/examples/aws/monitor/example.tfvars
@@ -3,17 +3,18 @@ region = "ap-northeast-1"
 base = "default" # bai, chiku, sho
 
 monitor = {
-  # resource_type                = "t3.small"
-  # resource_root_volume_size    = "64"
-  # resource_count               = "1"
-  # active_offset                = "0"
-  # encrypt_volume               = "true"
-  # enable_log_volume            = "true"
-  # log_volume_size              = "500"
-  # log_volume_type              = "sc1"
-  # enable_tdagent               = "true"
-  # log_retention_period_days    = "30"
-  # log_archive_storage_base_uri = "s3://your-bucket-name"
+  # resource_type                         = "t3.small"
+  # resource_root_volume_size             = "64"
+  # resource_count                        = "1"
+  # active_offset                         = "0"
+  # encrypt_volume                        = "true"
+  # enable_log_volume                     = "true"
+  # log_volume_size                       = "500"
+  # log_volume_type                       = "sc1"
+  # enable_tdagent                        = "true"
+  # log_retention_period_days             = "30"
+  # log_archive_storage_base_uri          = "s3://your-bucket-name"
+  # prometheus_data_retention_period_time = "90d"
 }
 
 # targets = [

--- a/examples/aws/monitor/example.tfvars
+++ b/examples/aws/monitor/example.tfvars
@@ -14,7 +14,7 @@ monitor = {
   # enable_tdagent                        = "true"
   # log_retention_period_days             = "30"
   # log_archive_storage_base_uri          = "s3://your-bucket-name"
-  # prometheus_data_retention_period_time = "90d"
+  # prometheus_data_retention_period_days = "90"
 }
 
 # targets = [

--- a/examples/azure/monitor/example.tfvars
+++ b/examples/azure/monitor/example.tfvars
@@ -1,19 +1,20 @@
 base = "default" # bai, chiku, sho
 
 monitor = {
-  # resource_type                 = "Standard_B2s"
-  # resource_root_volume_size     = "64"
-  # resource_count                = "1"
-  # active_offset                 = "0"
-  # enable_log_volume             = "true"
-  # log_volume_size               = "500"
-  # log_volume_type               = "Standard_LRS"
-  # enable_tdagent                = "true"
-  # set_public_access             = "false"
-  # remote_port                   = 9090
-  # enable_accelerated_networking = "false"
-  # log_retention_period_days     = "30"
-  # log_archive_storage_base_uri  = "https://yourstorageaccountname.blob.core.windows.net/your-container-name"
+  # resource_type                         = "Standard_B2s"
+  # resource_root_volume_size             = "64"
+  # resource_count                        = "1"
+  # active_offset                         = "0"
+  # enable_log_volume                     = "true"
+  # log_volume_size                       = "500"
+  # log_volume_type                       = "Standard_LRS"
+  # enable_tdagent                        = "true"
+  # set_public_access                     = "false"
+  # remote_port                           = 9090
+  # enable_accelerated_networking         = "false"
+  # log_retention_period_days             = "30"
+  # log_archive_storage_base_uri          = "https://yourstorageaccountname.blob.core.windows.net/your-container-name"
+  # prometheus_data_retention_period_time = "90d"
 }
 
 # targets = [

--- a/examples/azure/monitor/example.tfvars
+++ b/examples/azure/monitor/example.tfvars
@@ -14,7 +14,7 @@ monitor = {
   # enable_accelerated_networking         = "false"
   # log_retention_period_days             = "30"
   # log_archive_storage_base_uri          = "https://yourstorageaccountname.blob.core.windows.net/your-container-name"
-  # prometheus_data_retention_period_time = "90d"
+  # prometheus_data_retention_period_days = "90"
 }
 
 # targets = [

--- a/modules/aws/monitor/locals.tf
+++ b/modules/aws/monitor/locals.tf
@@ -24,17 +24,18 @@ locals {
 ### default
 locals {
   monitor_default = {
-    resource_type                = "t3.small"
-    resource_root_volume_size    = 64
-    resource_count               = 1
-    active_offset                = 0
-    encrypt_volume               = true
-    enable_log_volume            = true
-    log_volume_size              = 500
-    log_volume_type              = "sc1"
-    enable_tdagent               = true
-    log_retention_period_days    = 30
-    log_archive_storage_base_uri = ""
+    resource_type                         = "t3.small"
+    resource_root_volume_size             = 64
+    resource_count                        = 1
+    active_offset                         = 0
+    encrypt_volume                        = true
+    enable_log_volume                     = true
+    log_volume_size                       = 500
+    log_volume_type                       = "sc1"
+    enable_tdagent                        = true
+    log_retention_period_days             = 30
+    log_archive_storage_base_uri          = ""
+    prometheus_data_retention_period_time = "90d"
   }
 }
 

--- a/modules/aws/monitor/locals.tf
+++ b/modules/aws/monitor/locals.tf
@@ -35,7 +35,7 @@ locals {
     enable_tdagent                        = true
     log_retention_period_days             = 30
     log_archive_storage_base_uri          = ""
-    prometheus_data_retention_period_time = "90d"
+    prometheus_data_retention_period_days = "90"
   }
 }
 

--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -116,7 +116,7 @@ module "monitor_provision" {
   targets                               = var.targets
   log_retention_period_days             = local.monitor.log_retention_period_days
   log_archive_storage_info              = local.log_archive_storage_info
-  prometheus_data_retention_period_time = local.monitor.prometheus_data_retention_period_time
+  prometheus_data_retention_period_days = local.monitor.prometheus_data_retention_period_days
 }
 
 resource "aws_security_group" "monitor" {

--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -116,7 +116,7 @@ module "monitor_provision" {
   targets                               = var.targets
   log_retention_period_days             = local.monitor.log_retention_period_days
   log_archive_storage_info              = local.log_archive_storage_info
-  prometheus_data_retention_period_time = local.prometheus_data_retention_period_time
+  prometheus_data_retention_period_time = local.monitor.prometheus_data_retention_period_time
 }
 
 resource "aws_security_group" "monitor" {

--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -104,18 +104,19 @@ module "monitor_provision" {
   private_key_path = local.private_key_path
   provision_count  = local.monitor.resource_count
 
-  slack_webhook_url             = var.slack_webhook_url
-  network_id                    = local.network_id
-  scalardl_blue_resource_count  = local.scalardl_blue_resource_count
-  scalardl_green_resource_count = local.scalardl_green_resource_count
-  cassandra_resource_count      = local.cassandra_resource_count
-  replication_factor            = local.scalardl_replication_factor
-  network_name                  = local.network_name
-  enable_tdagent                = local.monitor.enable_tdagent
-  internal_domain               = local.internal_domain
-  targets                       = var.targets
-  log_retention_period_days     = local.monitor.log_retention_period_days
-  log_archive_storage_info      = local.log_archive_storage_info
+  slack_webhook_url                     = var.slack_webhook_url
+  network_id                            = local.network_id
+  scalardl_blue_resource_count          = local.scalardl_blue_resource_count
+  scalardl_green_resource_count         = local.scalardl_green_resource_count
+  cassandra_resource_count              = local.cassandra_resource_count
+  replication_factor                    = local.scalardl_replication_factor
+  network_name                          = local.network_name
+  enable_tdagent                        = local.monitor.enable_tdagent
+  internal_domain                       = local.internal_domain
+  targets                               = var.targets
+  log_retention_period_days             = local.monitor.log_retention_period_days
+  log_archive_storage_info              = local.log_archive_storage_info
+  prometheus_data_retention_period_time = local.prometheus_data_retention_period_time
 }
 
 resource "aws_security_group" "monitor" {

--- a/modules/azure/monitor/locals.tf
+++ b/modules/azure/monitor/locals.tf
@@ -24,19 +24,20 @@ locals {
 ### default
 locals {
   monitor_default = {
-    resource_type                 = "Standard_B2s"
-    resource_root_volume_size     = 64
-    resource_count                = 1
-    active_offset                 = 0
-    enable_log_volume             = true
-    log_volume_size               = 500
-    log_volume_type               = "Standard_LRS"
-    enable_tdagent                = true
-    set_public_access             = false
-    remote_port                   = 9090
-    enable_accelerated_networking = false
-    log_retention_period_days     = 30
-    log_archive_storage_base_uri  = ""
+    resource_type                         = "Standard_B2s"
+    resource_root_volume_size             = 64
+    resource_count                        = 1
+    active_offset                         = 0
+    enable_log_volume                     = true
+    log_volume_size                       = 500
+    log_volume_type                       = "Standard_LRS"
+    enable_tdagent                        = true
+    set_public_access                     = false
+    remote_port                           = 9090
+    enable_accelerated_networking         = false
+    log_retention_period_days             = 30
+    log_archive_storage_base_uri          = ""
+    prometheus_data_retention_period_time = "90d"
   }
 }
 

--- a/modules/azure/monitor/locals.tf
+++ b/modules/azure/monitor/locals.tf
@@ -37,7 +37,7 @@ locals {
     enable_accelerated_networking         = false
     log_retention_period_days             = 30
     log_archive_storage_base_uri          = ""
-    prometheus_data_retention_period_time = "90d"
+    prometheus_data_retention_period_days = "90d"
   }
 }
 

--- a/modules/azure/monitor/main.tf
+++ b/modules/azure/monitor/main.tf
@@ -94,7 +94,7 @@ module "monitor_provision" {
   targets                               = var.targets
   log_retention_period_days             = local.monitor.log_retention_period_days
   log_archive_storage_info              = local.log_archive_storage_info
-  prometheus_data_retention_period_time = local.prometheus_data_retention_period_time
+  prometheus_data_retention_period_time = local.monitor.prometheus_data_retention_period_time
 }
 
 resource "azurerm_private_dns_a_record" "monitor_cluster_dns" {

--- a/modules/azure/monitor/main.tf
+++ b/modules/azure/monitor/main.tf
@@ -94,7 +94,7 @@ module "monitor_provision" {
   targets                               = var.targets
   log_retention_period_days             = local.monitor.log_retention_period_days
   log_archive_storage_info              = local.log_archive_storage_info
-  prometheus_data_retention_period_time = local.monitor.prometheus_data_retention_period_time
+  prometheus_data_retention_period_days = local.monitor.prometheus_data_retention_period_days
 }
 
 resource "azurerm_private_dns_a_record" "monitor_cluster_dns" {

--- a/modules/azure/monitor/main.tf
+++ b/modules/azure/monitor/main.tf
@@ -82,18 +82,19 @@ module "monitor_provision" {
   private_key_path = local.private_key_path
   provision_count  = local.monitor.resource_count
 
-  slack_webhook_url             = var.slack_webhook_url
-  network_id                    = local.network_id
-  scalardl_blue_resource_count  = local.scalardl_blue_resource_count
-  scalardl_green_resource_count = local.scalardl_green_resource_count
-  cassandra_resource_count      = local.cassandra_resource_count
-  replication_factor            = local.scalardl_replication_factor
-  network_name                  = local.network_name
-  enable_tdagent                = local.monitor.enable_tdagent
-  internal_domain               = local.internal_domain
-  targets                       = var.targets
-  log_retention_period_days     = local.monitor.log_retention_period_days
-  log_archive_storage_info      = local.log_archive_storage_info
+  slack_webhook_url                     = var.slack_webhook_url
+  network_id                            = local.network_id
+  scalardl_blue_resource_count          = local.scalardl_blue_resource_count
+  scalardl_green_resource_count         = local.scalardl_green_resource_count
+  cassandra_resource_count              = local.cassandra_resource_count
+  replication_factor                    = local.scalardl_replication_factor
+  network_name                          = local.network_name
+  enable_tdagent                        = local.monitor.enable_tdagent
+  internal_domain                       = local.internal_domain
+  targets                               = var.targets
+  log_retention_period_days             = local.monitor.log_retention_period_days
+  log_archive_storage_info              = local.log_archive_storage_info
+  prometheus_data_retention_period_time = local.prometheus_data_retention_period_time
 }
 
 resource "azurerm_private_dns_a_record" "monitor_cluster_dns" {

--- a/modules/universal/monitor/main.tf
+++ b/modules/universal/monitor/main.tf
@@ -88,7 +88,7 @@ resource "null_resource" "monitor_container" {
       "export node_targets=${join(",", local.node_targets)}",
       "export monitor_targets=${join(",", local.monitor_targets)}",
       "export cadvisor_targets=${join(",", local.cadvisor_targets)}",
-      "export PROMETHEUS_DATA_RETENTION_PERIOD_TIME=${var.prometheus_data_retention_period_time}",
+      "export prometheus_data_retention_period_time=${var.prometheus_data_retention_period_days}d",
       "j2 ./prometheus/prometheus.yml.j2 > ./prometheus/prometheus.yml",
       "j2 ./prometheus/general_alert.rules.yml.j2 > ./prometheus/general_alert.rules.yml",
       "j2 ./prometheus/scalardl_alert.rules.yml.j2 > ./prometheus/scalardl_alert.rules.yml",

--- a/modules/universal/monitor/main.tf
+++ b/modules/universal/monitor/main.tf
@@ -88,6 +88,7 @@ resource "null_resource" "monitor_container" {
       "export node_targets=${join(",", local.node_targets)}",
       "export monitor_targets=${join(",", local.monitor_targets)}",
       "export cadvisor_targets=${join(",", local.cadvisor_targets)}",
+      "export PROMETHEUS_DATA_RETENTION_PERIOD_TIME=${var.prometheus_data_retention_period_time}",
       "j2 ./prometheus/prometheus.yml.j2 > ./prometheus/prometheus.yml",
       "j2 ./prometheus/general_alert.rules.yml.j2 > ./prometheus/general_alert.rules.yml",
       "j2 ./prometheus/scalardl_alert.rules.yml.j2 > ./prometheus/scalardl_alert.rules.yml",

--- a/modules/universal/monitor/provision/docker-compose.yml
+++ b/modules/universal/monitor/provision/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "--storage.tsdb.path=/prometheus"
       - "--web.console.libraries=/usr/share/prometheus/console_libraries"
       - "--web.console.templates=/usr/share/prometheus/consoles"
-      - "--storage.tsdb.retention.time=${PROMETHEUS_DATA_RETENTION_PERIOD_TIME}"
+      - "--storage.tsdb.retention.time=${prometheus_data_retention_period_time}"
     ports:
       - 9090:9090
     restart: always

--- a/modules/universal/monitor/provision/docker-compose.yml
+++ b/modules/universal/monitor/provision/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: "3.1"
 
 volumes:
   prometheus_data: {}
@@ -11,10 +11,11 @@ services:
       - ./prometheus:/etc/prometheus/
       - prometheus_data:/prometheus
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+      - "--storage.tsdb.retention.time=${PROMETHEUS_DATA_RETENTION_PERIOD_TIME}"
     ports:
       - 9090:9090
     restart: always
@@ -27,8 +28,8 @@ services:
       - ./alertmanager/:/etc/alertmanager/
     restart: always
     command:
-      - '--config.file=/etc/alertmanager/config.yml'
-      - '--storage.path=/alertmanager'
+      - "--config.file=/etc/alertmanager/config.yml"
+      - "--storage.path=/alertmanager"
 
   grafana:
     image: grafana/grafana:6.5.2

--- a/modules/universal/monitor/vars.tf
+++ b/modules/universal/monitor/vars.tf
@@ -75,3 +75,8 @@ variable "log_archive_storage_info" {
   default     = ""
   description = "An info to set archive storage of the accumulated logs in the monitor host"
 }
+
+variable "prometheus_data_retention_period_time" {
+  default     = "90d"
+  description = "Set the retention period of the prometheus data in the monitor host"
+}

--- a/modules/universal/monitor/vars.tf
+++ b/modules/universal/monitor/vars.tf
@@ -76,7 +76,7 @@ variable "log_archive_storage_info" {
   description = "An info to set archive storage of the accumulated logs in the monitor host"
 }
 
-variable "prometheus_data_retention_period_time" {
-  default     = "90d"
+variable "prometheus_data_retention_period_days" {
+  default     = "90"
   description = "Set the retention period of the prometheus data in the monitor host"
 }


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7214

# Done
- Add parameter to set data retention for Prometheus.
Support time unit: `y`, `w`, `d`, `h`,`m`,`s`
https://github.com/prometheus/prometheus/blob/v2.7.1/vendor/github.com/prometheus/common/model/time.go#L192-L207
- Default value is "90d" = 90days.

# Confirm
```
$ docker inspect xxx
    "Cmd": [
        "--config.file=/etc/prometheus/prometheus.yml",
        "--storage.tsdb.path=/prometheus",
        "--web.console.libraries=/usr/share/prometheus/console_libraries",
        "--web.console.templates=/usr/share/prometheus/consoles",
        "--storage.tsdb.retention.time=90d"
     ],
```