### PR TITLE
Fix output dns for envoy internal lb of aws

### DIFF
--- a/modules/aws/scalardl/envoy.tf
+++ b/modules/aws/scalardl/envoy.tf
@@ -273,7 +273,7 @@ resource "aws_lb_target_group_attachment" "envoy_privileged_target_group_attachm
 }
 
 resource "aws_route53_record" "envoy_dns_lb" {
-  count = local.envoy.enable_nlb ? 1 : 0
+  count = local.envoy.enable_nlb && local.envoy.nlb_internal ? 1 : 0
 
   zone_id = local.network_dns
   name    = "envoy-lb"

--- a/modules/aws/scalardl/output.tf
+++ b/modules/aws/scalardl/output.tf
@@ -39,7 +39,7 @@ output "scalardl_replication_factor" {
 }
 
 output "envoy_dns" {
-  value       = aws_lb.envoy_lb.*.dns_name
+  value       = local.envoy.enable_nlb ? (local.envoy.nlb_internal ? [aws_route53_record.envoy_dns_lb[0].fqdn] : aws_lb.envoy_lb.*.dns_name) : []
   description = "A list of DNS URLs to access an envoy cluster."
 }
 


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7236

# Done
Fix `envoy_dns` to output `envoy-lb.xxxx.xxx` when using internal LB in AWS.

# Confirm
- `nlb_internal = "true"` => internal lb
```
Outputs:

envoy_dns = envoy-lb.internal.scalar-labs.com
envoy_listen_port = 50051
scalardl_blue_resource_count = 1                                                                                                            scalardl_green_resource_count = 0
scalardl_replication_factor = 3
```
- `nlb_internal = "false"` => public lb
```
Outputs:

envoy_dns = tei-dns-ndf8j8-envoy-lb-6c2b58bd91ade460.elb.ap-northeast-1.amazonaws.com
envoy_listen_port = 50051
scalardl_blue_resource_count = 1
scalardl_green_resource_count = 0
scalardl_replication_factor = 3
```
- `enable_nlb = "false"` => no lb
```
Outputs:

envoy_dns =
envoy_listen_port = 50051
scalardl_blue_resource_count = 1
scalardl_green_resource_count = 0
scalardl_replication_factor = 3
```