### PR TITLE
Document modification: EBS data volume replacement

### DIFF
--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -81,7 +81,7 @@ terraform apply
 ```
 
 ### Taint Volume (with node replacement)
-The other option is to taint the volume which should be used as a last resort. This *will permanently delete data* on that volume and it will recreate data volume along with node. Be sure you can recover the data from a backup first.
+The other option is to taint the volume which should be used as a last resort. This *will permanently delete data* on that volume and it will recreate the node along with data or commit log volume. Be sure you can recover the data from a backup first.
 
 #### Azure
 ```console
@@ -100,7 +100,7 @@ terraform apply
 ```
 
 ### Taint Volume (without node replacement)
-The other option is to taint the volume which should be used as a last resort. This *will permanently delete data* on that volume and attach recreated volume with existing node. Be sure you can recover the data from a backup first.
+The other option is to taint the volume which should be used as a last resort. This *will permanently delete data* on that volume and attach the recreated data or commit log volume to the already existing instance. Be sure you can recover the data from a backup first.
 
 #### Azure
 ```console
@@ -136,15 +136,15 @@ sudo /bin/bash -c "echo 'UUID=af767839-b23d-4d1f-8a19-debbcfd6413c /data xfs def
 sudo mount -a
 ```
 
-#### Replacing the data volume without node replacement
+#### Replacing the taint volume without node replacement
 If you attached the new volume to the existing instance, you need to follow the these steps before starting Cassandra.
 
-* Replace the UUID of the `data` volume in `fstab`.
+* Replace the UUID of the `data` or `commitlog` volume in `fstab`.
 
 ```console 
 ssh -F ssh.cfg cassandra-[].internal.scalar-labs.com
 
-# Find the name of newly attached EBS data volume
+# Find the name of newly attached EBS volume
 lsblk -p -P -d -o name,serial,SIZE
 NAME="/dev/nvme2n1" SERIAL="vol018d1871d19da76f1" HCTL="" SIZE="1T"
 ...
@@ -152,12 +152,12 @@ NAME="/dev/nvme2n1" SERIAL="vol018d1871d19da76f1" HCTL="" SIZE="1T"
 # Create a file system in the newly created volume
 sudo mkfs -t xfs <name of volume>
 
-# Find the `UUID` of the data volume
+# Find the `UUID` of the data or commit log volume
 lsblk -p -P -d -o name,serial,UUID,SIZE
 NAME="/dev/nvme2n1" SERIAL="vol018d1871d19da76f1" UUID="af767839-b23d-4d1f-8a19-debbcfd6413c" HCTL="" SIZE="1T"
 ...
 
-# Update the UUID of `/data` directory 
+# Update the UUID of `/data` or `/commitlog` directory 
 sudo vi /etc/fstab
 
 sudo systemctl daemon-reload

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -12,7 +12,7 @@ cassandra = {
   resource_type             = "t3.large"
   resource_count            = 3
   resource_root_volume_size = 64
-  enable_data_volume        = true  
+  enable_data_volume        = true
   data_remote_volume_size   = 64
 }
 ```
@@ -103,7 +103,7 @@ After the volume is replaced, you will need to perform the following manual step
 
 * Replace the UUID of the `data` or `commitlog` volume in `fstab`.
 
-```console 
+```console
 ssh -F ssh.cfg cassandra-[].internal.scalar-labs.com
 
 # Find the name of newly attached EBS volume
@@ -119,14 +119,14 @@ lsblk -p -P -d -o name,serial,UUID,SIZE
 NAME="/dev/nvme2n1" SERIAL="vol018d1871d19da76f1" UUID="af767839-b23d-4d1f-8a19-debbcfd6413c" HCTL="" SIZE="1T"
 ...
 
-# Update the UUID of `/data` or `/commitlog` directory 
+# Update the UUID of `/data` or `/commitlog` directory
 sudo vi /etc/fstab
 
 sudo systemctl daemon-reload
 
 sudo mount -a
 
-# Change ownership of `/data` directory 
+# Change ownership of `/data` directory
 sudo chown cassandra:cassandra /data
 ```
 * Restore data from Cassy

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -80,10 +80,15 @@ terraform taint "module.cassandra.aws_volume_attachment.cassandra_data_volume_at
 terraform apply
 ```
 
-### Taint Volume (with node replacement)
-The other option is to taint the volume which should be used as a last resort. This *will permanently delete data* on that volume and it will recreate the node along with data or commit log volume. Be sure you can recover the data from a backup first.
+### Taint Volume
 
-#### Azure
+There are two other options for replacing the taint volume as a last resort.
+
+#### Replacing the node along with taint volume replacement
+
+This *will permanently delete data* on that volume and it will recreate the node along with data or commit log volume. Be sure you can recover the data from a backup first.
+
+##### Azure
 ```console
 terraform taint "module.cassandra.module.cassandra_cluster.azurerm_virtual_machine.vm-linux[0]"
 terraform taint "module.cassandra.azurerm_managed_disk.cassandra_data_volume[0]"
@@ -91,7 +96,7 @@ terraform taint "module.cassandra.azurerm_managed_disk.cassandra_data_volume[0]"
 terraform apply
 ```
 
-#### AWS
+##### AWS
 ```console
 terraform taint "module.cassandra.module.cassandra_cluster.aws_instance.this[0]"
 terraform taint "module.cassandra.aws_ebs_volume.cassandra_data_volume[0]"
@@ -99,17 +104,18 @@ terraform taint "module.cassandra.aws_ebs_volume.cassandra_data_volume[0]"
 terraform apply
 ```
 
-### Taint Volume (without node replacement)
-The other option is to taint the volume which should be used as a last resort. This *will permanently delete data* on that volume and attach the recreated data or commit log volume to the already existing instance. Be sure you can recover the data from a backup first.
+#### Replacing the taint volume without node replacement
 
-#### Azure
+This *will permanently delete data* on that volume and attach the recreated data or commit log volume to the already existing instance. Be sure you can recover the data from a backup first.
+
+##### Azure
 ```console
 terraform taint "module.cassandra.azurerm_managed_disk.cassandra_data_volume[0]"
 
 terraform apply
 ```
 
-#### AWS
+##### AWS
 ```console
 terraform taint "module.cassandra.aws_ebs_volume.cassandra_data_volume[0]"
 

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -37,7 +37,7 @@ This section explains what needs to be done for each case.
 
 When a node (VM or instance) is not working properly for some reason but the volume is fully functioning, only the node should be replaced with a new one.
 You can replace the node by tainting the VM or the instance and the volume attachment as described below.
-Note that, when you taint the volume attachment terraform will try to attach the same data or commit log volume to the new instance.
+Note that, when you taint the volume attachment, terraform will try to attach the same data or commit log volume to the new instance.
 
 #### Azure
 ```console
@@ -53,7 +53,7 @@ terraform taint "module.cassandra.aws_volume_attachment.cassandra_data_volume_at
 
 terraform apply
 ```
-#### Post Recovery Steps
+#### Post Terraform Steps
 After the Cassandra node is replaced, you will need to perform the following manual steps to get the node back in the cluster.
 
 * Find the UUID of the `data` or `commitlog` volume and add it to `fstab`.
@@ -81,7 +81,7 @@ Please note that, if you replace a seed node (IP-A), you should replace IP-A fro
 
 When the volume is not functioning properly for some reason but the node is alive, only the volume should be replaced with a new one.
 You can replace the volume by tainting the volume as described below.
-Note that this *will permanently delete data* on that volume and attach the recreated data or commit log volume to the already existing node. 
+Note that this *will permanently delete data* on that volume and attach the recreated data or commit log volume to the existing node.  
 When you do this, it is recommended to recover data from backup.
 
 #### Azure
@@ -98,7 +98,7 @@ terraform taint "module.cassandra.aws_ebs_volume.cassandra_data_volume[0]"
 terraform apply
 ```
 
-#### Post Recovery Steps
+#### Post Terraform Steps
 After the volume is replaced, you will need to perform the following manual steps to get the volume back in the node.
 
 * Replace the UUID of the `data` or `commitlog` volume in `fstab`.
@@ -137,7 +137,7 @@ sudo chown cassandra:cassandra /data
 
 When both a node and the volume are not working properly, both resources should be replaced with new ones.
 You can do it by tainting both resources as described below.
-Since the volume is replaced as the 2nd option, this *will permanently delete data* on that volume.
+Since the volume is replaced in the same manner as the 2nd option, the data on that volume will be permanently deleted.
 
 #### Azure
 ```console
@@ -155,7 +155,7 @@ terraform taint "module.cassandra.aws_ebs_volume.cassandra_data_volume[0]"
 terraform apply
 ```
 
-#### Post Recovery Steps
+#### Post Terraform Steps
 After the Cassandra node and volume are replaced, you will need to perform the following manual steps to get the node back in the cluster.
 
 * Restore data from Cassy

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -141,7 +141,7 @@ If you attached the new volume to the existing instance, you need to follow the 
 
 * Replace the UUID of the `data` volume in `fstab`.
 
-```
+```console 
 ssh -F ssh.cfg cassandra-[].internal.scalar-labs.com
 
 # Find the name of newly attached EBS data volume

--- a/docs/CassandraOperation.md
+++ b/docs/CassandraOperation.md
@@ -103,7 +103,7 @@ sudo mount -a
 
 Please note that, if you replace a seed node (IP-A), you should replace IP-A from seeds with a newly created Cassandra node IP in all the Cassandra nodes.
 
-### Case 2: Taint Volume with node replacement
+### Case 2: Taint volume with node replacement
 
 The other option is to taint the volume which should be used as a last resort. This *will permanently delete data* on that volume and it will recreate the node along with data or commit log volume. Be sure you can recover the data from a backup first.
 
@@ -138,7 +138,7 @@ After the Cassandra node and volume are replaced, you will need to perform the f
 
 Please note that, if you replace a seed node (IP-A), you should replace IP-A from seeds with a newly created Cassandra node IP in all the Cassandra nodes.
 
-### Case 3: Taint Volume without node replacement
+### Case 3: Taint volume without node replacement
 
 Another option is to taint the volume which should be used as a last resort. This *will permanently delete data* on that volume and attach the recreated data or commit log volume to the already existing instance. Be sure you can recover the data from a backup first.
 


### PR DESCRIPTION
Cassandra EBS data volume replacement steps modified with some additional steps.
- New steps added for EBS data volume replacement with existing node.
- Cassy backup restoration steps modified `Case3: Node and the volume are both replaced`