### PR TITLE
Refactoring install ansible in bastion

### DIFF
--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -3,6 +3,9 @@ name: Integration-test-with-terratest-for-AWS
 on:
   schedule:
     - cron: 0 15 * * *
+  pull_request:
+    branches:
+      - master
 
 jobs:
   terratest:

--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      TF_VERSION: 0.12.26
+      TF_VERSION: 0.12.29
 
     steps:
       - name: Checkout

--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -3,9 +3,6 @@ name: Integration-test-with-terratest-for-AWS
 on:
   schedule:
     - cron: 0 15 * * *
-  pull_request:
-    branches:
-      - master
 
 jobs:
   terratest:

--- a/provision/ansible/playbooks/roles/ansible/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/ansible/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: Install Ansible
-  command: python3 -m pip install ansible
+  pip:
+    name: ansible
+    state: present
+    executable: pip3

--- a/test/modules/awsdeploy/network/terraform.tfvars
+++ b/test/modules/awsdeploy/network/terraform.tfvars
@@ -16,5 +16,6 @@ additional_public_keys_path = "./additional_public_keys"
 internal_domain = "internal.scalar-labs.com"
 
 network = {
-  bastion_resource_count = 1
+  bastion_resource_count = "1"
+  bastion_resource_type  = "t3.large"
 }


### PR DESCRIPTION
# Description

Daily terratest failed in AWS.
https://scalar-labs.atlassian.net/browse/DLT-7223

📝 Workaround for Successful Testing.

# Done
- Refactoring `ansible` role.
- Fix resource type of bastion for terratest.
- Upgrade terraform version to 0.12.29 for terratest.