### PR TITLE
Fix td agent config to support multiline for cassandra

### DIFF
--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
@@ -12,7 +12,7 @@
   emit_unmatched_lines true
   <parse>
     @type multiline
-    format_firstline /^(?<level>[^ ]*) +\[(?<thread>[^\]]*)\] (?<time>[^ ]+ [^ ]+)/
+    format_firstline /^[^ ]* +\[[^\]]*\] [^ ]+ [^ ]+/
     format1 /^(?<level>[^ ]*) +\[(?<thread>[^\]]*)\] (?<time>[^ ]+ [^ ]+) (?<message>.*)$/
     time_format %Y-%m-%d %H:%M:%S,%N
   </parse>

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
@@ -11,8 +11,9 @@
   tag cassandra.system
   emit_unmatched_lines true
   <parse>
-    @type regexp
-    expression /^(?<level>[^ ]*) +\[(?<thread>[^\]]*)\] (?<time>[^ ]+ [^ ]+) (?<message>.*)$/
+    @type multiline
+    format_firstline /^(?<level>[^ ]*) +\[(?<thread>[^\]]*)\] (?<time>[^ ]+ [^ ]+)/
+    format1 /^(?<level>[^ ]*) +\[(?<thread>[^\]]*)\] (?<time>[^ ]+ [^ ]+) (?<message>.*)$/
     time_format %Y-%m-%d %H:%M:%S,%N
   </parse>
 </source>


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7288

```
2020-10-05T07:29:25+00:00       cassandra.system        {"level":"ERROR","thread":"main","message":"CassandraDaemon.java:785 - Exception encountered during startup","hostname":"cassandra-1"}
2020-10-05T07:29:25+00:00       cassandra.system        {"unmatched_line":"java.lang.RuntimeException: Unable to gossip with any peers","hos
tname":"cassandra-1"}
2020-10-05T07:29:25+00:00       cassandra.system        {"unmatched_line":"\tat org.apache.cassandra.gms.Gossiper.doShadowRound(Gossiper.jav
a:1544) ~[apache-cassandra-3.11.8.jar:3.11.8]","hostname":"cassandra-1"}
2020-10-05T07:29:25+00:00       cassandra.system        {"unmatched_line":"\tat org.apache.cassandra.service.StorageService.checkForEndpoint
Collision(StorageService.java:592) ~[apache-cassandra-3.11.8.jar:3.11.8]","hostname":"cassandra-1"}
2020-10-05T07:29:25+00:00       cassandra.system        {"unmatched_line":"\tat org.apache.cassandra.service.StorageService.prepareToJoin(St
orageService.java:850) ~[apache-cassandra-3.11.8.jar:3.11.8]","hostname":"cassandra-1"}
2020-10-05T07:29:25+00:00       cassandra.system        {"unmatched_line":"\tat org.apache.cassandra.service.StorageService.initServer(Stora
geService.java:709) ~[apache-cassandra-3.11.8.jar:3.11.8]","hostname":"cassandra-1"}
2020-10-05T07:29:25+00:00       cassandra.system        {"unmatched_line":"\tat org.apache.cassandra.service.StorageService.initServer(Stora
geService.java:658) ~[apache-cassandra-3.11.8.jar:3.11.8]","hostname":"cassandra-1"}
2020-10-05T07:29:25+00:00       cassandra.system        {"unmatched_line":"\tat org.apache.cassandra.service.CassandraDaemon.setup(Cassandra
Daemon.java:386) [apache-cassandra-3.11.8.jar:3.11.8]","hostname":"cassandra-1"}
2020-10-05T07:29:25+00:00       cassandra.system        {"unmatched_line":"\tat org.apache.cassandra.service.CassandraDaemon.activate(Cassan
draDaemon.java:628) [apache-cassandra-3.11.8.jar:3.11.8]","hostname":"cassandra-1"}
2020-10-05T07:29:25+00:00       cassandra.system        {"unmatched_line":"\tat org.apache.cassandra.service.CassandraDaemon.main(CassandraD
aemon.java:768) [apache-cassandra-3.11.8.jar:3.11.8]","hostname":"cassandra-1"}
```

# Done
Fix to use `multiline` type instead of `regexp`

# Confirm
- Cassandra system.log
```
ERROR [main] 2020-10-05 07:04:12,499 CassandraDaemon.java:785 - Exception encountered during startup
java.lang.RuntimeException: Unable to gossip with any peers
        at org.apache.cassandra.gms.Gossiper.doShadowRound(Gossiper.java:1544) ~[apache-cassandra-3.11.8.jar:3.11.8]
        at org.apache.cassandra.service.StorageService.checkForEndpointCollision(StorageService.java:592) ~[apache-cassandra-3.11.8.jar:3.11.8]
        at org.apache.cassandra.service.StorageService.prepareToJoin(StorageService.java:850) ~[apache-cassandra-3.11.8.jar:3.11.8]
        at org.apache.cassandra.service.StorageService.initServer(StorageService.java:709) ~[apache-cassandra-3.11.8.jar:3.11.8]
        at org.apache.cassandra.service.StorageService.initServer(StorageService.java:658) ~[apache-cassandra-3.11.8.jar:3.11.8]
        at org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:386) [apache-cassandra-3.11.8.jar:3.11.8]
        at org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:628) [apache-cassandra-3.11.8.jar:3.11.8]
        at org.apache.cassandra.service.CassandraDaemon.main(CassandraDaemon.java:768) [apache-cassandra-3.11.8.jar:3.11.8]
```
- Cassandra log forwarded to the monitor server
```
2020-10-05T07:04:12+00:00       cassandra.system        {"level":"ERROR","thread":"main","message":"CassandraDaemon.java:785 - Exception encountered during startup\njava.lang.RuntimeException: Unable to gossip with any peers\n\tat org.apache.cassandra.gms.Gossiper.doShadowRound(Gossiper.java:1544) ~[apache-cassandra-3.11.8.jar:3.11.8]\n\tat org.apache.cassandra.service.StorageService.checkForEndpointCollision(StorageService.java:592) ~[apache-cassandra-3.11.8.jar:3.11.8]\n\tat org.apache.cassandra.service.StorageService.prepareToJoin(StorageService.java:850) ~[apache-cassandra-3.11.8.jar:3.11.8]\n\tat org.apache.cassandra.service.StorageService.initServer(StorageService.java:709) ~[apache-cassandra-3.11.8.jar:3.11.8]\n\tat org.apache.cassandra.service.StorageService.initServer(StorageService.java:658) ~[apache-cassandra-3.11.8.jar:3.11.8]\n\tat org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:386) [apache-cassandra-3.11.8.jar:3.11.8]\n\tat org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:628) [apache-cassandra-3.11.8.jar:3.11.8]\n\tat org.apache.cassandra.service.CassandraDaemon.main(CassandraDaemon.java:768) [apache-cassandra-3.11.8.jar:3.11.8]","hostname":"cassandra-1"}
```

# Ref
https://docs.fluentd.org/parser/multiline