### PR TITLE
Make monitor module use external volume always

### DIFF
--- a/examples/aws/monitor/example.tfvars
+++ b/examples/aws/monitor/example.tfvars
@@ -8,7 +8,6 @@ monitor = {
   # resource_count                        = "1"
   # active_offset                         = "0"
   # encrypt_volume                        = "true"
-  # enable_log_volume                     = "true"
   # log_volume_size                       = "500"
   # log_volume_type                       = "sc1"
   # enable_tdagent                        = "true"

--- a/examples/azure/monitor/example.tfvars
+++ b/examples/azure/monitor/example.tfvars
@@ -5,7 +5,6 @@ monitor = {
   # resource_root_volume_size             = "64"
   # resource_count                        = "1"
   # active_offset                         = "0"
-  # enable_log_volume                     = "true"
   # log_volume_size                       = "500"
   # log_volume_type                       = "Standard_LRS"
   # enable_tdagent                        = "true"

--- a/modules/aws/monitor/locals.tf
+++ b/modules/aws/monitor/locals.tf
@@ -29,7 +29,6 @@ locals {
     resource_count                        = 1
     active_offset                         = 0
     encrypt_volume                        = true
-    enable_log_volume                     = true
     log_volume_size                       = 500
     log_volume_type                       = "sc1"
     enable_tdagent                        = true

--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -42,7 +42,7 @@ module "monitor_cluster" {
 }
 
 resource "aws_ebs_volume" "monitor_log_volume" {
-  count = local.monitor.enable_tdagent && local.monitor.enable_log_volume ? local.monitor.resource_count : 0
+  count = local.monitor.enable_tdagent ? local.monitor.resource_count : 0
 
   availability_zone = local.locations[count.index % length(local.locations)]
   size              = local.monitor.log_volume_size
@@ -60,7 +60,7 @@ resource "aws_ebs_volume" "monitor_log_volume" {
 }
 
 resource "aws_volume_attachment" "monitor_log_volume_attachment" {
-  count = local.monitor.enable_tdagent && local.monitor.enable_log_volume ? local.monitor.resource_count : 0
+  count = local.monitor.enable_tdagent ? local.monitor.resource_count : 0
 
   device_name = "/dev/xvdh"
   volume_id   = aws_ebs_volume.monitor_log_volume[count.index].id
@@ -70,7 +70,7 @@ resource "aws_volume_attachment" "monitor_log_volume_attachment" {
 }
 
 resource "null_resource" "volume_data" {
-  count = local.monitor.enable_tdagent && local.monitor.enable_log_volume ? local.monitor.resource_count : 0
+  count = local.monitor.enable_tdagent ? local.monitor.resource_count : 0
 
   triggers = {
     volume_attachment_ids = join(

--- a/modules/azure/monitor/locals.tf
+++ b/modules/azure/monitor/locals.tf
@@ -28,7 +28,6 @@ locals {
     resource_root_volume_size             = 64
     resource_count                        = 1
     active_offset                         = 0
-    enable_log_volume                     = true
     log_volume_size                       = 500
     log_volume_type                       = "Standard_LRS"
     enable_tdagent                        = true

--- a/modules/azure/monitor/main.tf
+++ b/modules/azure/monitor/main.tf
@@ -26,7 +26,7 @@ module "monitor_cluster" {
 }
 
 resource "azurerm_managed_disk" "monitor_log_volume" {
-  count = local.monitor.resource_count
+  count = local.monitor.enable_tdagent ? local.monitor.resource_count : 0
 
   name                 = "log-${count.index + 1}"
   location             = local.region
@@ -38,7 +38,7 @@ resource "azurerm_managed_disk" "monitor_log_volume" {
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "monitor_log_volume_attachment" {
-  count = local.monitor.resource_count
+  count = local.monitor.enable_tdagent ? local.monitor.resource_count : 0
 
   managed_disk_id    = azurerm_managed_disk.monitor_log_volume[count.index].id
   virtual_machine_id = module.monitor_cluster.vm_ids[count.index]
@@ -47,7 +47,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "monitor_log_volume_atta
 }
 
 resource "null_resource" "volume_data" {
-  count = local.monitor.resource_count
+  count = local.monitor.enable_tdagent ? local.monitor.resource_count : 0
 
   triggers = {
     volume_attachment_ids = join(

--- a/modules/azure/monitor/main.tf
+++ b/modules/azure/monitor/main.tf
@@ -26,7 +26,7 @@ module "monitor_cluster" {
 }
 
 resource "azurerm_managed_disk" "monitor_log_volume" {
-  count = local.monitor.enable_log_volume ? local.monitor.resource_count : 0
+  count = local.monitor.resource_count
 
   name                 = "log-${count.index + 1}"
   location             = local.region
@@ -38,7 +38,7 @@ resource "azurerm_managed_disk" "monitor_log_volume" {
 }
 
 resource "azurerm_virtual_machine_data_disk_attachment" "monitor_log_volume_attachment" {
-  count = local.monitor.enable_log_volume ? local.monitor.resource_count : 0
+  count = local.monitor.resource_count
 
   managed_disk_id    = azurerm_managed_disk.monitor_log_volume[count.index].id
   virtual_machine_id = module.monitor_cluster.vm_ids[count.index]
@@ -47,7 +47,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "monitor_log_volume_atta
 }
 
 resource "null_resource" "volume_data" {
-  count = local.monitor.enable_log_volume ? local.monitor.resource_count : 0
+  count = local.monitor.resource_count
 
   triggers = {
     volume_attachment_ids = join(

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/files/drive_mount.sh
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/files/drive_mount.sh
@@ -7,13 +7,10 @@ if mountpoint -q /log; then
   exit 0
 fi
 
-# Use root volume if LOG_STORE is not set
+# Fail if LOG_STORE is not set
 if [[ -z "$LOG_STORE" ]]; then
-  # Create /log directory at the root
-  echo "LOG_STORE is not set: Using Root Volume"
-  mkdir -p /log
-  chown td-agent:td-agent /log
-  exit 0
+  echo "ERROR: LOG_STORE is not set"
+  exit 1
 fi
 
 mount_log_volume () {


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6177

Removed the option `enable_log_volume` from the monitor module. An external volume should always be created to store logs.
