### PR TITLE
Refactoring triggers for update cassandra config

### DIFF
--- a/modules/universal/cassandra/main.tf
+++ b/modules/universal/cassandra/main.tf
@@ -24,11 +24,10 @@ resource "null_resource" "cassandra_waitfor" {
 }
 
 resource "null_resource" "cassandra" {
-  count      = var.provision_count
-  depends_on = [null_resource.cassandra_waitfor]
+  count = var.provision_count
 
   triggers = {
-    triggers = var.vm_ids[count.index]
+    triggers = null_resource.cassandra_waitfor[count.index].id
   }
 
   connection {


### PR DESCRIPTION
# Description
The Cassandra config is not updated by changing the instance_type.

# Done
Fix to use `cassandra_waitfor` for triggers instead `vm_ids`.

# Confirm
```
  # module.cassandra.module.cassandra_provision.null_resource.cassandra[0] must be replaced                                            [573/12699]
-/+ resource "null_resource" "cassandra" {
      ~ id       = "5386767767388688332" -> (known after apply)
      ~ triggers = {
          - "triggers" = "i-0b16b0c3529f5881f"
        } -> (known after apply) # forces replacement
    }

  # module.cassandra.module.cassandra_provision.null_resource.cassandra[1] must be replaced
-/+ resource "null_resource" "cassandra" {
      ~ id       = "6378479453704558095" -> (known after apply)
      ~ triggers = {
          - "triggers" = "i-0102ee7340fe629a8"
        } -> (known after apply) # forces replacement
    }

  # module.cassandra.module.cassandra_provision.null_resource.cassandra[2] must be replaced
-/+ resource "null_resource" "cassandra" {
      ~ id       = "3671813800215072783" -> (known after apply)
      ~ triggers = {
          - "triggers" = "i-05c7d7488ce3e54e5"
        } -> (known after apply) # forces replacement
    }

  # module.cassandra.module.cassandra_provision.null_resource.cassandra_waitfor[0] must be replaced
-/+ resource "null_resource" "cassandra_waitfor" {
      ~ id       = "170923916993472432" -> (known after apply)
      ~ triggers = { # forces replacement
          ~ "triggers" = "871986139252697661,t3.large" -> "871986139252697661,r5d.large"
            "vm_id"    = "i-0b16b0c3529f5881f"
        }
    }

  # module.cassandra.module.cassandra_provision.null_resource.cassandra_waitfor[1] must be replaced
-/+ resource "null_resource" "cassandra_waitfor" {
      ~ id       = "7086052489776489918" -> (known after apply)
```