### PR TITLE
Replace scalardl-schema-loader-cassandra with scalardl-schema-loader

### DIFF
--- a/modules/universal/scalardl/vars.tf
+++ b/modules/universal/scalardl/vars.tf
@@ -42,14 +42,9 @@ variable "replication_factor" {
   description = "Set the replication factor for schema"
 }
 
-variable "schema_loader_cassandra_image_name" {
-  default     = "scalarlabs/scalardl-schema-loader-cassandra"
-  description = "The docker image name for the schema loader for Cassandra"
-}
-
-variable "schema_loader_cassandra_image_tag" {
-  default     = "1.0.0"
-  description = "The docker image tag for the schema loader for Cassandra"
+variable "schema_loader_image" {
+  default     = "scalarlabs/scalardl-schema-loader:1.1.0"
+  description = "The docker image for the schema loader"
 }
 
 variable "enable_tdagent" {


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-7405

This PR migrates`scalardl-schema-loader-cassandra` to [the unified `scalardl-schema-loader`](https://github.com/scalar-labs/scalardl-schema-loader/tree/v1.1.0) in scalar-terraform.

This is the first step to support DynamoDB. Note that the current `scalarlabs/scalardl-schema-loader:1.1.0` doesn't support DynamoDB yet, so it will be updated when the DynamoDB support is added.