### PR TITLE
Fix to use standard ssd for azure scalardl

### DIFF
--- a/modules/azure/scalardl/cluster/main.tf
+++ b/modules/azure/scalardl/cluster/main.tf
@@ -12,6 +12,7 @@ module "cluster" {
   vnet_subnet_id                = var.subnet_id
   vm_size                       = var.resource_type
   ssh_key                       = var.public_key_path
+  storage_account_type          = "Standard_LRS"
   storage_os_disk_size          = var.resource_root_volume_size
   availability_set_id           = var.availability_set_id
   delete_os_disk_on_termination = true

--- a/modules/azure/scalardl/cluster/main.tf
+++ b/modules/azure/scalardl/cluster/main.tf
@@ -12,7 +12,7 @@ module "cluster" {
   vnet_subnet_id                = var.subnet_id
   vm_size                       = var.resource_type
   ssh_key                       = var.public_key_path
-  storage_account_type          = "Standard_LRS"
+  storage_account_type          = "StandardSSD_LRS"
   storage_os_disk_size          = var.resource_root_volume_size
   availability_set_id           = var.availability_set_id
   delete_os_disk_on_termination = true

--- a/modules/azure/scalardl/envoy.tf
+++ b/modules/azure/scalardl/envoy.tf
@@ -18,7 +18,7 @@ module "envoy_cluster" {
   vnet_subnet_id                = local.envoy.subnet_id
   vm_size                       = local.envoy.resource_type
   ssh_key                       = local.public_key_path
-  storage_account_type          = "Standard_LRS"
+  storage_account_type          = "StandardSSD_LRS"
   storage_os_disk_size          = local.envoy.resource_root_volume_size
   delete_os_disk_on_termination = true
   remote_port                   = local.envoy.target_port

--- a/modules/azure/scalardl/envoy.tf
+++ b/modules/azure/scalardl/envoy.tf
@@ -18,6 +18,7 @@ module "envoy_cluster" {
   vnet_subnet_id                = local.envoy.subnet_id
   vm_size                       = local.envoy.resource_type
   ssh_key                       = local.public_key_path
+  storage_account_type          = "Standard_LRS"
   storage_os_disk_size          = local.envoy.resource_root_volume_size
   delete_os_disk_on_termination = true
   remote_port                   = local.envoy.target_port


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7571

# Done
- Fix to use `standard ssd` in envoy and scalardl VM in Azure.

# Ref
https://azure.microsoft.com/en-us/blog/preview-standard-ssd-disks-for-azure-virtual-machine-workloads/