### PR TITLE
Fixed cassandra version

### DIFF
--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+cassandra_version: 3.11.8
+cassandra_rpm_url: http://archive.apache.org/dist/cassandra/redhat/311x/cassandra-{{ cassandra_version }}-1.noarch.rpm
 tuned_profile: virtual-guest
 # Only Cassandra disks are tuned and OS disks are not tuned.
 # In AWS, sda and xvda are used depending on virtualization types.
@@ -11,4 +13,4 @@ CASSANDRA_STATE: stopped
 cassandra_dc_id: dc1
 cassandra_rack_id: rack1
 endpoint_snitch: GossipingPropertyFileSnitch
-vm_max_map_count: 1048575
+vm_max_map_count: "1048575"

--- a/provision/ansible/playbooks/roles/cassandra/files/cassandra.repo
+++ b/provision/ansible/playbooks/roles/cassandra/files/cassandra.repo
@@ -1,6 +1,0 @@
-[cassandra]
-name=Apache Cassandra
-baseurl=https://downloads.apache.org/cassandra/redhat/311x/
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://downloads.apache.org/cassandra/KEYS

--- a/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/tasks/main.yml
@@ -72,28 +72,6 @@
     daemon_reload: yes
     state: started
 
-- name: Add Cassandra Repo Debian
-  lineinfile:
-    line: "deb https://downloads.apache.org/cassandra/debian 311x main"
-    path: /etc/apt/sources.list.d/cassandra.sources.list
-    create: yes
-  when: ansible_facts['os_family'] == "Debian"
-
-- name: Add Keys
-  shell: curl https://downloads.apache.org/cassandra/KEYS | apt-key add -
-  when: ansible_facts['os_family'] == "Debian"
-
-- name: Apt Update
-  shell: apt update
-  when: ansible_facts['os_family'] == "Debian"
-
-- name: Add Cassandra Repo
-  copy:
-    src: cassandra.repo
-    dest: /etc/yum.repos.d/cassandra.repo
-    mode: 0644
-  when: ansible_facts['os_family'] == "RedHat"
-
 - name: Install jemalloc
   package:
     name: jemalloc
@@ -105,7 +83,7 @@
 
 - name: Install Cassandra
   package:
-    name: cassandra
+    name: "{{ cassandra_rpm_url }}"
     state: present
   register: install_cassandra_result
   until: install_cassandra_result is succeeded


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7486

# Done
- Fixed cassandra version using rpm install.
- Fix type warning.
```
[WARNING]: The value "1048575" (type int) was converted to "u'1048575'" (type string)
```
- Remove support for debian.

# Confirm
```
[centos@cassandra-1 ~]$ rpm -qa |grep cassandra
cassandra-3.11.8-1.noarch

[centos@cassandra-1 ~]$ cassandra -v
3.11.8

[centos@cassandra-1 ~]$ cqlsh --version
cqlsh 5.0.1

[centos@cassandra-1 ~]$ nodetool status
Datacenter: dc1
===============
Status=Up/Down
|/ State=Normal/Leaving/Joining/Moving
--  Address    Load       Tokens       Owns (effective)  Host ID                               Rack
UN  10.42.2.6  84.17 KiB  256          63.2%             7c31a476-b2ad-4842-9cab-fec49526bd09  rack1
UN  10.42.2.4  69.92 KiB  256          66.7%             9bb7c942-b3ae-4040-aec3-9cd2c2e24b68  rack1
UN  10.42.2.5  70.01 KiB  256          70.1%             9a22e7e5-ea4c-4721-add0-bdefa72ee575  rack1

```
