### PR TITLE
Fix terraform in github actions

### DIFF
--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -18,9 +18,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Terraform
-        uses: autero1/action-terraform@v0.1.0
+        uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
 
       - name: Docker login
         run: echo ${DOCKER_PASSWORD} | docker login -u scalartest --password-stdin docker.io

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -20,9 +20,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Terraform
-        uses: autero1/action-terraform@v0.1.0
+        uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: ${{ env.TF_VERSION }}
+          terraform_wrapper: false
 
       - name: Docker login
         run: echo ${DOCKER_PASSWORD} | docker login -u scalartest --password-stdin docker.io

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -3,6 +3,9 @@ name: Integration-test-with-terratest-for-Azure
 on:
   schedule:
     - cron: 0 15 * * *
+  pull_request:
+    branches:
+      - master
 
 jobs:
   terratest:
@@ -13,7 +16,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-      TF_VERSION: 0.12.26
+      TF_VERSION: 0.12.29
 
     steps:
       - name: Checkout

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -3,9 +3,6 @@ name: Integration-test-with-terratest-for-Azure
 on:
   schedule:
     - cron: 0 15 * * *
-  pull_request:
-    branches:
-      - master
 
 jobs:
   terratest:
@@ -16,7 +13,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
       ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
       ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
-      TF_VERSION: 0.12.29
+      TF_VERSION: 0.12.26
 
     steps:
       - name: Checkout

--- a/modules/universal/scalardl/vars.tf
+++ b/modules/universal/scalardl/vars.tf
@@ -43,7 +43,7 @@ variable "replication_factor" {
 }
 
 variable "schema_loader_image" {
-  default     = "scalarlabs/scalardl-schema-loader:1.1.0"
+  default     = "scalarlabs/scalardl-schema-loader:1.2.0"
   description = "The docker image for the schema loader"
 }
 


### PR DESCRIPTION
# Description
https://github.com/scalar-labs/scalar-terraform/runs/1454188153?check_suite_focus=true
```
Error: Unable to process command '::add-path::/opt/hostedtoolcache/terraform/0.12.26/x64' successfully.
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

# Done
- Fix to use `hashicorp/setup-terraform@v1`
- Up terraform version to `0.12.29`
- Fix to use `scalardl-schema-loader:1.2.0`

# Confirm
Success
https://github.com/scalar-labs/scalar-terraform/runs/1462804017?check_suite_focus=true