### PR TITLE
Fix to use 2.0.9 for scalardl-java-client-sdk in terratest

### DIFF
--- a/.github/workflows/aws_terratest.yml
+++ b/.github/workflows/aws_terratest.yml
@@ -33,7 +33,7 @@ jobs:
           curl -L https://github.com/scalar-labs/scalardl-java-client-sdk/archive/v${SCALARDL_JAVA_CLIENT_SDK_VERSION}.tar.gz | tar xvzf -
           mv ./scalardl-java-client-sdk-${SCALARDL_JAVA_CLIENT_SDK_VERSION} ./scalardl-java-client-sdk
         env:
-          SCALARDL_JAVA_CLIENT_SDK_VERSION: 2.0.3
+          SCALARDL_JAVA_CLIENT_SDK_VERSION: 2.0.9
         working-directory: ./test/src/integration
 
       - name: Set up GO

--- a/.github/workflows/azure_terratest.yml
+++ b/.github/workflows/azure_terratest.yml
@@ -35,7 +35,7 @@ jobs:
           curl -L https://github.com/scalar-labs/scalardl-java-client-sdk/archive/v${SCALARDL_JAVA_CLIENT_SDK_VERSION}.tar.gz | tar xvzf -
           mv ./scalardl-java-client-sdk-${SCALARDL_JAVA_CLIENT_SDK_VERSION} ./scalardl-java-client-sdk
         env:
-          SCALARDL_JAVA_CLIENT_SDK_VERSION: 2.0.3
+          SCALARDL_JAVA_CLIENT_SDK_VERSION: 2.0.9
         working-directory: ./test/src/integration
 
       - name: Set up GO


### PR DESCRIPTION
# Description

Fix to use `2.0.9` for scalardl-java-client-sdk in terratest.

ref:
#242