### PR TITLE
Fix local variable in aws/scalardl module

### DIFF
--- a/modules/aws/scalardl/locals.tf
+++ b/modules/aws/scalardl/locals.tf
@@ -16,7 +16,11 @@ locals {
   green_subnet_ids   = split(",", var.network.green_subnet_ids)
   internal_domain    = var.network.internal_domain
 
-  triggers = [var.scalardl.database == "cassandra" && var.cassandra.start_on_initial_boot ? var.cassandra.provision_ids : var.network.bastion_provision_id]
+  triggers = [
+    (lookup(var.scalardl, "database", "cassandra") == "cassandra" && var.cassandra.start_on_initial_boot) ?
+    var.cassandra.provision_ids :
+    var.network.bastion_provision_id
+  ]
 }
 
 ### default


### PR DESCRIPTION
This PR fixes a failing GitHub Actions test in #244.

A key in a map variable `var.scalardl` might be absent if it's not passed from a `tfvars` file.
The test failed because a non-existent key, `var.scalardl.database`, was accessed.

https://github.com/scalar-labs/scalar-terraform/pull/244/checks?check_run_id=1472473832

```
  on ../../../../modules/aws/scalardl/locals.tf line 19, in locals:
  19:   triggers = [var.scalardl.database == "cassandra" && var.cassandra.start_on_initial_boot ? var.cassandra.provision_ids : var.network.bastion_provision_id]
    |----------------
    | var.scalardl is empty map of dynamic
```
