### PR TITLE
Fix max_pods to 10 for Azure k8s module

### DIFF
--- a/modules/azure/kubernetes/kubernetes.tf
+++ b/modules/azure/kubernetes/kubernetes.tf
@@ -59,7 +59,7 @@ resource "azuread_service_principal_password" "sp_password" {
   }
 }
 
-# Retrieve scope id for assignment 
+# Retrieve scope id for assignment
 data "azurerm_subscription" "current" {
 }
 
@@ -104,7 +104,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     max_pods              = local.kubernetes_default_node_pool.max_pods
     os_disk_size_gb       = local.kubernetes_default_node_pool.os_disk_size_gb
     vnet_subnet_id        = azurerm_subnet.k8s_private["k8s_node_pod"].id
-    enable_node_public_ip = "false"
+    enable_node_public_ip = false
     enable_auto_scaling   = local.kubernetes_default_node_pool.cluster_auto_scaling
     min_count             = local.kubernetes_default_node_pool.cluster_auto_scaling_min_count
     max_count             = local.kubernetes_default_node_pool.cluster_auto_scaling_max_count
@@ -137,7 +137,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     var.custom_tags,
     {
       Terraform = "true"
-      Network   = "${local.network_name}"
+      Network   = local.network_name
       Role      = "kubernetes"
     }
   )
@@ -166,7 +166,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "aks_cluster_scalar_apps_node_po
   os_type               = local.kubernetes_scalar_apps_pool.node_os
   vnet_subnet_id        = azurerm_subnet.k8s_private["k8s_node_pod"].id
   node_taints           = [local.kubernetes_scalar_apps_pool.taints]
-  enable_node_public_ip = "false"
+  enable_node_public_ip = false
   enable_auto_scaling   = local.kubernetes_scalar_apps_pool.cluster_auto_scaling
   min_count             = local.kubernetes_scalar_apps_pool.cluster_auto_scaling_min_count
   max_count             = local.kubernetes_scalar_apps_pool.cluster_auto_scaling_max_count
@@ -175,7 +175,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "aks_cluster_scalar_apps_node_po
     var.custom_tags,
     {
       terraform = "true"
-      network   = "${local.network_name}"
+      network   = local.network_name
       role      = "kubernetes"
     }
   )

--- a/modules/azure/kubernetes/locals.tf
+++ b/modules/azure/kubernetes/locals.tf
@@ -52,13 +52,13 @@ locals {
 locals {
   kubernetes_node_pool = {
     name                           = "default"
-    node_count                     = "3"
+    node_count                     = 3
     vm_size                        = "Standard_D2s_v3"
-    max_pods                       = "100"
-    os_disk_size_gb                = "64"
-    cluster_auto_scaling           = "true"
-    cluster_auto_scaling_min_count = "3"
-    cluster_auto_scaling_max_count = "6"
+    max_pods                       = 10
+    os_disk_size_gb                = 64
+    cluster_auto_scaling           = true
+    cluster_auto_scaling_min_count = 3
+    cluster_auto_scaling_max_count = 6
   }
 }
 
@@ -74,15 +74,15 @@ locals {
 locals {
   scalar_apps_pool = {
     name                           = "scalardlpool"
-    node_count                     = "3"
+    node_count                     = 3
     vm_size                        = "Standard_D2s_v3"
-    max_pods                       = "100"
-    os_disk_size_gb                = "64"
+    max_pods                       = 10
+    os_disk_size_gb                = 64
     node_os                        = "Linux"
     taints                         = "kubernetes.io/app=scalardlpool:NoSchedule"
-    cluster_auto_scaling           = "true"
-    cluster_auto_scaling_min_count = "3"
-    cluster_auto_scaling_max_count = "6"
+    cluster_auto_scaling           = true
+    cluster_auto_scaling_min_count = 3
+    cluster_auto_scaling_max_count = 6
   }
 }
 

--- a/modules/azure/kubernetes/locals.tf
+++ b/modules/azure/kubernetes/locals.tf
@@ -14,7 +14,7 @@ locals {
       address_prefixes  = [cidrsubnet(local.network_cidr, 6, 10)]
       service_endpoints = var.use_cosmosdb ? ["Microsoft.AzureCosmosDB"] : []
     }
-    k8s_ingress  = {
+    k8s_ingress = {
       address_prefixes = [cidrsubnet(local.network_cidr, 6, 11)]
     }
   }


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-7862

- 6 pod / node (min)
```
Non-terminated Pods:         (6 in total)
  Namespace                  Name                                         CPU Requests  CPU Limits   Memory Requests  Memory Limits  AGE
  ---------                  ----                                         ------------  ----------   ---------------  -------------  ---
  default                    prod-scalardl-ledger-b8bb6ddc8-stkq4         1 (52%)       1500m (78%)  2Gi (38%)        3Gi (57%)      7m15s
  kube-system                azure-cni-networkmonitor-97srp               0 (0%)        0 (0%)       0 (0%)           0 (0%)         4m58s
  kube-system                azure-ip-masq-agent-lgxjg                    100m (5%)     500m (26%)   50Mi (0%)        250Mi (4%)     4m58s
  kube-system                kube-proxy-9ggmz                             100m (5%)     0 (0%)       0 (0%)           0 (0%)         4m58s
  logging                    fluent-bit-dg7gm                             0 (0%)        0 (0%)       0 (0%)           0 (0%)         4m57s
  monitoring                 prometheus-prometheus-node-exporter-zspc7    0 (0%)        0 (0%)       0 (0%)           0 (0%)         4m58s
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource                       Requests      Limits
  --------                       --------      ------
  cpu                            1200m (63%)   2 (105%)
  memory                         2098Mi (38%)  3322Mi (61%)
  ephemeral-storage              0 (0%)        0 (0%)
  attachable-volumes-azure-disk  0             0
```
- 9 pod / node
```
Non-terminated Pods:         (9 in total)
  Namespace                  Name                                         CPU Requests  CPU Limits   Memory Requests  Memory Limits  AGE
  ---------                  ----                                         ------------  ----------   ---------------  -------------  ---
  default                    prod-scalardl-envoy-7cdbcc9945-9m2ts         200m (10%)    300m (15%)   256Mi (4%)       328Mi (6%)     31m
  default                    prod-scalardl-envoy-7cdbcc9945-f727k         200m (10%)    300m (15%)   256Mi (4%)       328Mi (6%)     31m
  default                    prod-scalardl-envoy-7cdbcc9945-txcjf         200m (10%)    300m (15%)   256Mi (4%)       328Mi (6%)     31m
  default                    prod-scalardl-ledger-b8bb6ddc8-cgswt         1 (52%)       1500m (78%)  2Gi (38%)        3Gi (57%)      31m
  kube-system                azure-cni-networkmonitor-t52jk               0 (0%)        0 (0%)       0 (0%)           0 (0%)         41m
  kube-system                azure-ip-masq-agent-q7h2b                    100m (5%)     500m (26%)   50Mi (0%)        250Mi (4%)     41m
  kube-system                kube-proxy-xh2w4                             100m (5%)     0 (0%)       0 (0%)           0 (0%)         41m
  logging                    fluent-bit-bn5xt                             0 (0%)        0 (0%)       0 (0%)           0 (0%)         24m
  monitoring                 prometheus-prometheus-node-exporter-pcqxf    0 (0%)        0 (0%)       0 (0%)           0 (0%)         26m
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource                       Requests      Limits
  --------                       --------      ------
  cpu                            1800m (94%)   2900m (152%)
  memory                         2866Mi (53%)  4306Mi (79%)
  ephemeral-storage              0 (0%)        0 (0%)
  attachable-volumes-azure-disk  0             0
```

# Done
- Fix `max_pods` to 10 per node (`Standard_D2s_v3`)
Only one `scalardl` pod will be placed in a node. (resource CPU request : 1000m, node CPU: 1900m)
- Fix variable type

# Confirm
envoy: 12, scalardl: 12
```
[centos@bastion-1 ~]$ kubectl get pods -A                                                                                                                                    NAMESPACE     NAME                                                     READY   STATUS      RESTARTS   AGE
default       load-schema-schema-loading-5r9dr                         0/1     Completed   0          42m
default       prod-scalardl-envoy-7cdbcc9945-4l8fn                     1/1     Running     0          42m
default       prod-scalardl-envoy-7cdbcc9945-9m2ts                     1/1     Running     0          42m
default       prod-scalardl-envoy-7cdbcc9945-cdl5b                     1/1     Running     0          15m
default       prod-scalardl-envoy-7cdbcc9945-chwm8                     1/1     Running     0          15m
default       prod-scalardl-envoy-7cdbcc9945-dzktc                     1/1     Running     0          42m
default       prod-scalardl-envoy-7cdbcc9945-f727k                     1/1     Running     0          42m
default       prod-scalardl-envoy-7cdbcc9945-fjbl8                     1/1     Running     0          15m
default       prod-scalardl-envoy-7cdbcc9945-jsncj                     1/1     Running     0          15m
default       prod-scalardl-envoy-7cdbcc9945-qhkwh                     1/1     Running     0          42m
default       prod-scalardl-envoy-7cdbcc9945-txcjf                     1/1     Running     0          42m
default       prod-scalardl-envoy-7cdbcc9945-xglw5                     1/1     Running     0          15m
default       prod-scalardl-envoy-7cdbcc9945-xqx8x                     1/1     Running     0          42m
default       prod-scalardl-ledger-b8bb6ddc8-2lrbl                     1/1     Running     0          15m
default       prod-scalardl-ledger-b8bb6ddc8-5gpnp                     1/1     Running     0          42m
default       prod-scalardl-ledger-b8bb6ddc8-7rn2w                     1/1     Running     0          42m
default       prod-scalardl-ledger-b8bb6ddc8-99tpz                     1/1     Running     0          15m
default       prod-scalardl-ledger-b8bb6ddc8-b5zs9                     1/1     Running     0          15m
default       prod-scalardl-ledger-b8bb6ddc8-cgswt                     1/1     Running     0          42m
default       prod-scalardl-ledger-b8bb6ddc8-cml8x                     1/1     Running     0          42m
default       prod-scalardl-ledger-b8bb6ddc8-mpg4f                     1/1     Running     0          42m
default       prod-scalardl-ledger-b8bb6ddc8-p8xwq                     1/1     Running     0          42m
default       prod-scalardl-ledger-b8bb6ddc8-stkq4                     1/1     Running     0          15m
default       prod-scalardl-ledger-b8bb6ddc8-thwx4                     1/1     Running     0          15m
default       prod-scalardl-ledger-b8bb6ddc8-zh98w                     1/1     Running     0          42m
kube-system   azure-cni-networkmonitor-5rkmv                           1/1     Running     0          52m
kube-system   azure-cni-networkmonitor-6wgzc                           1/1     Running     0          12m
kube-system   azure-cni-networkmonitor-7gbml                           1/1     Running     0          12m
kube-system   azure-cni-networkmonitor-97srp                           1/1     Running     0          12m
kube-system   azure-cni-networkmonitor-9twfb                           1/1     Running     0          52m
kube-system   azure-cni-networkmonitor-f24g8                           1/1     Running     0          55m
kube-system   azure-cni-networkmonitor-gx5hl                           1/1     Running     0          52m
kube-system   azure-cni-networkmonitor-gzvlz                           1/1     Running     0          55m
kube-system   azure-cni-networkmonitor-j2dgb                           1/1     Running     0          23m
kube-system   azure-cni-networkmonitor-j7t2c                           1/1     Running     0          52m
kube-system   azure-cni-networkmonitor-k4zcj                           1/1     Running     0          12m
kube-system   azure-cni-networkmonitor-l5lgf                           1/1     Running     0          55m
kube-system   azure-cni-networkmonitor-mvf42                           1/1     Running     0          52m
kube-system   azure-cni-networkmonitor-qwcwb                           1/1     Running     0          55m
kube-system   azure-cni-networkmonitor-t52jk                           1/1     Running     0          53m
kube-system   azure-cni-networkmonitor-vr98v                           1/1     Running     0          12m
kube-system   azure-cni-networkmonitor-xchj2                           1/1     Running     0          55m
kube-system   azure-cni-networkmonitor-zwvq7                           1/1     Running     0          55m
kube-system   azure-ip-masq-agent-45lwj                                1/1     Running     0          55m
kube-system   azure-ip-masq-agent-8w7th                                1/1     Running     0          12m
kube-system   azure-ip-masq-agent-bjbvj                                1/1     Running     0          12m
kube-system   azure-ip-masq-agent-bz9wr                                1/1     Running     0          55m
kube-system   azure-ip-masq-agent-h756s                                1/1     Running     0          23m
kube-system   azure-ip-masq-agent-j58v6                                1/1     Running     0          55m
kube-system   azure-ip-masq-agent-knp9f                                1/1     Running     0          55m
kube-system   azure-ip-masq-agent-lcpsx                                1/1     Running     0          12m
kube-system   azure-ip-masq-agent-ldq2q                                1/1     Running     0          55m
kube-system   azure-ip-masq-agent-lgxjg                                1/1     Running     0          12m
kube-system   azure-ip-masq-agent-ljdbw                                1/1     Running     0          52m
kube-system   azure-ip-masq-agent-mc958                                1/1     Running     0          52m
kube-system   azure-ip-masq-agent-nk9m6                                1/1     Running     0          52m
kube-system   azure-ip-masq-agent-nmq8p                                1/1     Running     0          52m
kube-system   azure-ip-masq-agent-q7h2b                                1/1     Running     0          53m
kube-system   azure-ip-masq-agent-s6q9v                                1/1     Running     0          55m
kube-system   azure-ip-masq-agent-v5q8s                                1/1     Running     0          52m
kube-system   azure-ip-masq-agent-x2kjw                                1/1     Running     0          12m
kube-system   coredns-79766dfd68-tpfct                                 1/1     Running     0          52m
kube-system   coredns-79766dfd68-wlp6s                                 1/1     Running     0          12m
kube-system   coredns-79766dfd68-wtm6m                                 1/1     Running     0          60m
kube-system   coredns-79766dfd68-xgx6j                                 1/1     Running     0          55m
kube-system   coredns-autoscaler-66c578cddb-qk99l                      1/1     Running     0          60m
kube-system   dashboard-metrics-scraper-6587ff9d84-cdccg               1/1     Running     0          60m
kube-system   kube-proxy-78bks                                         1/1     Running     0          55m
kube-system   kube-proxy-9ggmz                                         1/1     Running     0          12m
kube-system   kube-proxy-d7f59                                         1/1     Running     0          55m
kube-system   kube-proxy-ftsj8                                         1/1     Running     0          12m
kube-system   kube-proxy-h8nq4                                         1/1     Running     0          12m
kube-system   kube-proxy-htgr2                                         1/1     Running     0          52m
kube-system   kube-proxy-l8gp4                                         1/1     Running     0          55m
kube-system   kube-proxy-n6sw5                                         1/1     Running     0          12m
kube-system   kube-proxy-nm8jl                                         1/1     Running     0          55m
kube-system   kube-proxy-qxtbq                                         1/1     Running     0          52m
kube-system   kube-proxy-s67ch                                         1/1     Running     0          52m
kube-system   kube-proxy-tk4bp                                         1/1     Running     0          55m
kube-system   kube-proxy-v5q7z                                         1/1     Running     0          52m
kube-system   kube-proxy-vxn6q                                         1/1     Running     0          55m
kube-system   kube-proxy-wmpl4                                         1/1     Running     0          23m
kube-system   kube-proxy-xh2w4                                         1/1     Running     0          53m
kube-system   kube-proxy-z9vv8                                         1/1     Running     0          52m
kube-system   kube-proxy-zhz8s                                         1/1     Running     0          12m
kube-system   kubernetes-dashboard-64ccc85575-2g7wz                    1/1     Running     1          60m
kube-system   metrics-server-7f5b4f6d8c-c54f5                          1/1     Running     0          60m
kube-system   tunnelfront-76cd46798c-hbctk                             1/1     Running     0          60m
logging       fluent-bit-42k86                                         1/1     Running     0          12m
logging       fluent-bit-6qdnb                                         1/1     Running     0          35m
logging       fluent-bit-bn5xt                                         1/1     Running     0          35m
logging       fluent-bit-cqcfw                                         1/1     Running     0          35m
logging       fluent-bit-dg7gm                                         1/1     Running     0          12m
logging       fluent-bit-f9bfz                                         1/1     Running     0          35m
logging       fluent-bit-jtrxv                                         1/1     Running     0          35m
logging       fluent-bit-ncr9j                                         1/1     Running     0          35m
logging       fluent-bit-qbqmd                                         1/1     Running     0          23m
logging       fluent-bit-rf4pc                                         1/1     Running     0          12m
logging       fluent-bit-rmkff                                         1/1     Running     0          35m
logging       fluent-bit-rmxbj                                         1/1     Running     0          35m
logging       fluent-bit-rvbd5                                         1/1     Running     0          35m
logging       fluent-bit-v485q                                         1/1     Running     0          35m
logging       fluent-bit-vn24c                                         1/1     Running     0          35m
logging       fluent-bit-wgdp5                                         1/1     Running     0          12m
logging       fluent-bit-wkdqt                                         1/1     Running     0          12m
logging       fluent-bit-zm6zd                                         1/1     Running     0          35m
monitoring    alertmanager-prometheus-prometheus-oper-alertmanager-0   2/2     Running     0          37m
monitoring    prometheus-grafana-599cbc6bf6-pskgc                      2/2     Running     0          37m
monitoring    prometheus-kube-state-metrics-7844d8fc49-dbhf7           1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-5v5nz                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-87ggb                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-9th8g                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-h5qrp                1/1     Running     0          12m
monitoring    prometheus-prometheus-node-exporter-hwdw5                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-mq986                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-mrw5x                1/1     Running     0          23m
monitoring    prometheus-prometheus-node-exporter-pcqxf                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-q6tsc                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-rx4xx                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-swngc                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-t6k5q                1/1     Running     0          12m
monitoring    prometheus-prometheus-node-exporter-t6ztn                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-wqwqt                1/1     Running     0          12m
monitoring    prometheus-prometheus-node-exporter-wxpt4                1/1     Running     0          12m
monitoring    prometheus-prometheus-node-exporter-xcq2c                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-xj4kk                1/1     Running     0          37m
monitoring    prometheus-prometheus-node-exporter-zspc7                1/1     Running     0          12m
monitoring    prometheus-prometheus-oper-operator-67ccf47d85-zrlz2     2/2     Running     0          37m
monitoring    prometheus-prometheus-prometheus-oper-prometheus-0       3/3     Running     1          37m
```