### PR TITLE
Add Fluentd metrics to Prometheus

### DIFF
--- a/modules/aws/cassandra/cassandra.tf
+++ b/modules/aws/cassandra/cassandra.tf
@@ -324,6 +324,19 @@ resource "aws_security_group_rule" "cassandra_node_exporter" {
   security_group_id = aws_security_group.cassandra[count.index].id
 }
 
+resource "aws_security_group_rule" "cassandra_fluentd_prometheus" {
+  count = local.cassandra.resource_count > 0 && local.cassandra.enable_tdagent ? 1 : 0
+
+  type        = "ingress"
+  from_port   = 24231
+  to_port     = 24231
+  protocol    = "tcp"
+  cidr_blocks = [local.network_cidr]
+  description = "Cassandra fluentd-plugin-prometheus"
+
+  security_group_id = aws_security_group.cassandra[count.index].id
+}
+
 resource "aws_security_group_rule" "cassandra_egress" {
   count = local.cassandra.resource_count > 0 ? 1 : 0
 
@@ -379,6 +392,20 @@ resource "aws_route53_record" "node_exporter_dns_srv" {
   ttl     = "300"
   records = formatlist(
     "0 0 9100 %s.%s",
+    aws_route53_record.cassandra_dns.*.name,
+    "${local.internal_domain}.",
+  )
+}
+
+resource "aws_route53_record" "fluentd_prometheus_dns_srv" {
+  count = local.cassandra.resource_count > 0 && local.cassandra.enable_tdagent ? 1 : 0
+
+  zone_id = local.network_dns
+  name    = "_fluentd._tcp.cassandra"
+  type    = "SRV"
+  ttl     = "300"
+  records = formatlist(
+    "0 0 24231 %s.%s",
     aws_route53_record.cassandra_dns.*.name,
     "${local.internal_domain}.",
   )

--- a/modules/aws/cassandra/reaper.tf
+++ b/modules/aws/cassandra/reaper.tf
@@ -125,6 +125,19 @@ resource "aws_security_group_rule" "reaper_cadvisor" {
   security_group_id = aws_security_group.reaper[count.index].id
 }
 
+resource "aws_security_group_rule" "reaper_fluentd_prometheus" {
+  count = local.reaper.resource_count > 0 && local.reaper.enable_tdagent ? 1 : 0
+
+  type        = "ingress"
+  from_port   = 24231
+  to_port     = 24231
+  protocol    = "tcp"
+  cidr_blocks = [local.network_cidr]
+  description = "Reaper fluentd-plugin-prometheus"
+
+  security_group_id = aws_security_group.reaper[count.index].id
+}
+
 resource "aws_security_group_rule" "reaper_egress" {
   count = local.reaper.resource_count > 0 ? 1 : 0
 
@@ -185,6 +198,20 @@ resource "aws_route53_record" "reaper_node_exporter_dns_srv" {
   ttl     = "300"
   records = formatlist(
     "0 0 9100 %s.%s",
+    aws_route53_record.reaper_dns.*.name,
+    "${local.internal_domain}.",
+  )
+}
+
+resource "aws_route53_record" "reaper_fluentd_prometheus_dns_srv" {
+  count = local.reaper.resource_count > 0 && local.reaper.enable_tdagent ? 1 : 0
+
+  zone_id = local.network_dns
+  name    = "_fluentd._tcp.reaper"
+  type    = "SRV"
+  ttl     = "300"
+  records = formatlist(
+    "0 0 24231 %s.%s",
     aws_route53_record.reaper_dns.*.name,
     "${local.internal_domain}.",
   )

--- a/modules/aws/monitor/main.tf
+++ b/modules/aws/monitor/main.tf
@@ -227,6 +227,19 @@ resource "aws_security_group_rule" "monitor_fluentd_udp" {
   security_group_id = aws_security_group.monitor[count.index].id
 }
 
+resource "aws_security_group_rule" "monitor_fluentd_prometheus" {
+  count = local.monitor.resource_count > 0 && local.monitor.enable_tdagent ? 1 : 0
+
+  type        = "ingress"
+  from_port   = 24231
+  to_port     = 24231
+  protocol    = "tcp"
+  cidr_blocks = [local.network_cidr]
+  description = "Monitor fluentd-plugin-prometheus"
+
+  security_group_id = aws_security_group.monitor[count.index].id
+}
+
 resource "aws_security_group_rule" "monitor_nginx" {
   count = local.monitor.resource_count > 0 ? 1 : 0
 
@@ -295,6 +308,20 @@ resource "aws_route53_record" "node_exporter_dns_srv" {
   ttl     = "300"
   records = formatlist(
     "0 0 9100 %s.%s",
+    aws_route53_record.monitor_host_dns.*.name,
+    "${local.internal_domain}.",
+  )
+}
+
+resource "aws_route53_record" "fluentd_prometheus_dns_srv" {
+  count = local.monitor.resource_count > 0 && local.monitor.enable_tdagent ? 1 : 0
+
+  zone_id = local.network_dns
+  name    = "_fluentd._tcp.monitor"
+  type    = "SRV"
+  ttl     = "300"
+  records = formatlist(
+    "0 0 24231 %s.%s",
     aws_route53_record.monitor_host_dns.*.name,
     "${local.internal_domain}.",
   )

--- a/modules/aws/scalardl/scalardl.tf
+++ b/modules/aws/scalardl/scalardl.tf
@@ -153,6 +153,19 @@ resource "aws_security_group_rule" "scalardl_cadvisor" {
   security_group_id = aws_security_group.scalardl[count.index].id
 }
 
+resource "aws_security_group_rule" "scalardl_fluentd_prometheus" {
+  count = (local.scalardl.green_resource_count > 0 || local.scalardl.blue_resource_count > 0) && local.scalardl.enable_tdagent ? 1 : 0
+
+  type        = "ingress"
+  from_port   = 24231
+  to_port     = 24231
+  protocol    = "tcp"
+  cidr_blocks = [local.network_cidr]
+  description = "Scalar DL fluentd-plugin-prometheus"
+
+  security_group_id = aws_security_group.scalardl[count.index].id
+}
+
 resource "aws_security_group_rule" "scalardl_egress" {
   count = local.scalardl.green_resource_count > 0 || local.scalardl.blue_resource_count > 0 ? 1 : 0
 
@@ -250,6 +263,34 @@ resource "aws_route53_record" "scalardl_green_node_exporter_dns_srv" {
   ttl     = "300"
   records = formatlist(
     "0 0 9100 %s.%s",
+    aws_route53_record.scalardl_green_dns.*.name,
+    "${local.internal_domain}.",
+  )
+}
+
+resource "aws_route53_record" "scalardl_blue_fluentd_prometheus_dns_srv" {
+  count = local.scalardl.blue_resource_count > 0 && local.scalardl.enable_tdagent ? 1 : 0
+
+  zone_id = local.network_dns
+  name    = "_fluentd._tcp.scalardl-blue"
+  type    = "SRV"
+  ttl     = "300"
+  records = formatlist(
+    "0 0 24231 %s.%s",
+    aws_route53_record.scalardl_blue_dns.*.name,
+    "${local.internal_domain}.",
+  )
+}
+
+resource "aws_route53_record" "scalardl_green_fluentd_prometheus_dns_srv" {
+  count = local.scalardl.green_resource_count > 0 && local.scalardl.enable_tdagent ? 1 : 0
+
+  zone_id = local.network_dns
+  name    = "_fluentd._tcp.scalardl-green"
+  type    = "SRV"
+  ttl     = "300"
+  records = formatlist(
+    "0 0 24231 %s.%s",
     aws_route53_record.scalardl_green_dns.*.name,
     "${local.internal_domain}.",
   )

--- a/modules/azure/cassandra/cassandra.tf
+++ b/modules/azure/cassandra/cassandra.tf
@@ -234,3 +234,23 @@ resource "azurerm_private_dns_srv_record" "cassanda_exporter_dns_srv" {
     }
   }
 }
+
+resource "azurerm_private_dns_srv_record" "cassandra_fluentd_prometheus_dns_srv" {
+  count = local.cassandra.resource_count > 0 && local.cassandra.enable_tdagent ? 1 : 0
+
+  name                = "_fluentd._tcp.cassandra"
+  zone_name           = local.network_dns
+  resource_group_name = local.network_name
+  ttl                 = 300
+
+  dynamic record {
+    for_each = azurerm_private_dns_a_record.cassandra_dns.*.name
+
+    content {
+      priority = 0
+      weight   = 0
+      port     = 24231
+      target   = "${record.value}.${local.internal_domain}"
+    }
+  }
+}

--- a/modules/azure/cassandra/cassy.tf
+++ b/modules/azure/cassandra/cassy.tf
@@ -103,3 +103,23 @@ resource "azurerm_private_dns_srv_record" "cassy_cadvisor_dns_srv" {
     }
   }
 }
+
+resource "azurerm_private_dns_srv_record" "cassy_fluentd_prometheus_dns_srv" {
+  count = local.cassy.resource_count > 0 && local.cassy.enable_tdagent ? 1 : 0
+
+  name                = "_fluentd._tcp.cassy"
+  zone_name           = local.network_dns
+  resource_group_name = local.network_name
+  ttl                 = 300
+
+  dynamic record {
+    for_each = azurerm_private_dns_a_record.cassy_dns.*.name
+
+    content {
+      priority = 0
+      weight   = 0
+      port     = 24231
+      target   = "${record.value}.${local.internal_domain}"
+    }
+  }
+}

--- a/modules/azure/cassandra/reaper.tf
+++ b/modules/azure/cassandra/reaper.tf
@@ -103,3 +103,23 @@ resource "azurerm_private_dns_srv_record" "reaper_cadvisor_dns_srv" {
     }
   }
 }
+
+resource "azurerm_private_dns_srv_record" "reaper_fluentd_prometheus_dns_srv" {
+  count = local.reaper.resource_count > 0 && local.reaper.enable_tdagent ? 1 : 0
+
+  name                = "_fluentd._tcp.reaper"
+  zone_name           = local.network_dns
+  resource_group_name = local.network_name
+  ttl                 = 300
+
+  dynamic record {
+    for_each = azurerm_private_dns_a_record.reaper_dns.*.name
+
+    content {
+      priority = 0
+      weight   = 0
+      port     = 24231
+      target   = "${record.value}.${local.internal_domain}"
+    }
+  }
+}

--- a/modules/azure/monitor/main.tf
+++ b/modules/azure/monitor/main.tf
@@ -158,3 +158,23 @@ resource "azurerm_private_dns_srv_record" "monitor_cadvisor_dns_srv" {
     }
   }
 }
+
+resource "azurerm_private_dns_srv_record" "monitor_fluentd_prometheus_dns_srv" {
+  count = local.monitor.resource_count > 0 && local.monitor.enable_tdagent ? 1 : 0
+
+  name                = "_fluentd._tcp.monitor"
+  zone_name           = local.network_dns
+  resource_group_name = local.network_name
+  ttl                 = 300
+
+  dynamic record {
+    for_each = azurerm_private_dns_a_record.monitor_host_dns.*.name
+
+    content {
+      priority = 0
+      weight   = 0
+      port     = 24231
+      target   = "${record.value}.${local.internal_domain}"
+    }
+  }
+}

--- a/modules/azure/network/bastion/main.tf
+++ b/modules/azure/network/bastion/main.tf
@@ -61,3 +61,23 @@ resource "azurerm_private_dns_srv_record" "bastion_dns_srv" {
     }
   }
 }
+
+resource "azurerm_private_dns_srv_record" "bastion_fluentd_prometheus_dns_srv" {
+  count = var.resource_count > 0 && var.enable_tdagent ? 1 : 0
+
+  name                = "_fluentd._tcp.bastion"
+  zone_name           = var.network_dns
+  resource_group_name = var.network_name
+  ttl                 = 300
+
+  dynamic record {
+    for_each = azurerm_private_dns_a_record.bastion_dns_a.*.name
+
+    content {
+      priority = 0
+      weight   = 0
+      port     = 24231
+      target   = "${record.value}.${var.network_dns}"
+    }
+  }
+}

--- a/modules/azure/scalardl/envoy.tf
+++ b/modules/azure/scalardl/envoy.tf
@@ -264,3 +264,23 @@ resource "azurerm_private_dns_srv_record" "envoy_cadvisor_dns_srv" {
     }
   }
 }
+
+resource "azurerm_private_dns_srv_record" "envoy_fluentd_prometheus_dns_srv" {
+  count = local.envoy.resource_count > 0 && local.envoy.enable_tdagent ? 1 : 0
+
+  name                = "_fluentd._tcp.envoy"
+  zone_name           = local.network_dns
+  resource_group_name = local.network_name
+  ttl                 = 300
+
+  dynamic record {
+    for_each = azurerm_private_dns_a_record.envoy_dns.*.name
+
+    content {
+      priority = 0
+      weight   = 0
+      port     = 24231
+      target   = "${record.value}.${local.internal_domain}"
+    }
+  }
+}

--- a/modules/azure/scalardl/scalardl.tf
+++ b/modules/azure/scalardl/scalardl.tf
@@ -197,6 +197,46 @@ resource "azurerm_private_dns_srv_record" "cadvisor_green_dns_srv" {
   }
 }
 
+resource "azurerm_private_dns_srv_record" "fluentd_prometheus_blue_dns_srv" {
+  count = local.scalardl.blue_resource_count > 0 ? 1 : 0
+
+  name                = "_fluentd._tcp.scalardl-blue"
+  zone_name           = local.network_dns
+  resource_group_name = local.network_name
+  ttl                 = 300
+
+  dynamic record {
+    for_each = azurerm_private_dns_a_record.scalardl_blue_dns.*.name
+
+    content {
+      priority = 0
+      weight   = 0
+      port     = 24231
+      target   = "${record.value}.${local.internal_domain}"
+    }
+  }
+}
+
+resource "azurerm_private_dns_srv_record" "fluentd_prometheus_green_dns_srv" {
+  count = local.scalardl.green_resource_count > 0 ? 1 : 0
+
+  name                = "_fluentd._tcp.scalardl-green"
+  zone_name           = local.network_dns
+  resource_group_name = local.network_name
+  ttl                 = 300
+
+  dynamic record {
+    for_each = azurerm_private_dns_a_record.scalardl_green_dns.*.name
+
+    content {
+      priority = 0
+      weight   = 0
+      port     = 24231
+      target   = "${record.value}.${local.internal_domain}"
+    }
+  }
+}
+
 resource "azurerm_private_dns_srv_record" "scalardl_dns_srv" {
   count = local.scalardl.green_resource_count > 0 || local.scalardl.blue_resource_count > 0 ? 1 : 0
 

--- a/modules/universal/monitor/locals.tf
+++ b/modules/universal/monitor/locals.tf
@@ -7,4 +7,5 @@ locals {
   service_targets  = setunion(local.scalardl_targets, local.cassandra_targets, local.cassandra_ops_targets)
   node_targets     = setunion(local.service_targets, ["bastion", "monitor"])
   cadvisor_targets = setunion(local.scalardl_targets, local.cassandra_ops_targets, ["monitor"])
+  fluentd_targets  = setunion(local.scalardl_targets, local.cassandra_targets, local.cassandra_ops_targets, ["bastion", "monitor"])
 }

--- a/modules/universal/monitor/main.tf
+++ b/modules/universal/monitor/main.tf
@@ -88,6 +88,7 @@ resource "null_resource" "monitor_container" {
       "export node_targets=${join(",", local.node_targets)}",
       "export monitor_targets=${join(",", local.monitor_targets)}",
       "export cadvisor_targets=${join(",", local.cadvisor_targets)}",
+      "export fluentd_targets=${join(",", local.fluentd_targets)}",
       "export prometheus_data_retention_period_time=${var.prometheus_data_retention_period_days}d",
       "j2 ./prometheus/prometheus.yml.j2 > ./prometheus/prometheus.yml",
       "j2 ./prometheus/general_alert.rules.yml.j2 > ./prometheus/general_alert.rules.yml",

--- a/modules/universal/monitor/provision/prometheus/prometheus.yml.j2
+++ b/modules/universal/monitor/provision/prometheus/prometheus.yml.j2
@@ -7,6 +7,7 @@ global:
 {%- set service_list = service_targets.split(',') -%}
 {%- set node_list = node_targets.split(',') -%}
 {%- set cadvisor_list = cadvisor_targets.split(',') %}
+{%- set fluentd_list = fluentd_targets.split(',') %}
 
 rule_files:
   - general_alert.rules.yml
@@ -81,6 +82,16 @@ scrape_configs:
     - names:
     {%- for s in cadvisor_list %}
       - _cadvisor._tcp.{{ s }}.{{ internal_domain }}
+    {%- endfor %}
+    relabel_configs:
+    - *relabel_role
+
+  - job_name: fluentd
+    metrics_path: /metrics
+    dns_sd_configs:
+    - names:
+    {%- for s in fluentd_list %}
+      - _fluentd._tcp.{{ s }}.{{ internal_domain }}
     {%- endfor %}
     relabel_configs:
     - *relabel_role

--- a/provision/ansible/playbooks/bastion-server.yml
+++ b/provision/ansible/playbooks/bastion-server.yml
@@ -10,6 +10,7 @@
   vars:
     tdagent_confd_templates:
       - { src: "templates/td-agent-confd/td-agent-bastion.conf.j2", dest: "bastion.conf" }
+      - { src: "templates/td-agent-confd/metrics.conf.j2", dest: "metrics.conf" }
   gather_facts: yes
   become: yes
 

--- a/provision/ansible/playbooks/cassandra-server.yml
+++ b/provision/ansible/playbooks/cassandra-server.yml
@@ -9,6 +9,7 @@
   vars:
     tdagent_confd_templates:
       - { src: "templates/td-agent-confd/td-agent-cassandra.conf.j2", dest: "cassandra.conf" }
+      - { src: "templates/td-agent-confd/metrics.conf.j2", dest: "metrics.conf" }
   gather_facts: yes
   become: yes
 

--- a/provision/ansible/playbooks/docker-server.yml
+++ b/provision/ansible/playbooks/docker-server.yml
@@ -7,6 +7,7 @@
   vars:
     tdagent_confd_templates:
       - { src: "templates/td-agent-confd/td-agent-docker.conf.j2", dest: "docker.conf" }
+      - { src: "templates/td-agent-confd/metrics.conf.j2", dest: "metrics.conf" }
   gather_facts: yes
   become: yes
 

--- a/provision/ansible/playbooks/monitor-server.yml
+++ b/provision/ansible/playbooks/monitor-server.yml
@@ -9,6 +9,7 @@
   vars:
     tdagent_confd_templates:
       - { src: "templates/td-agent-confd/td-agent-monitor.conf.j2", dest: "monitor.conf" }
+      - { src: "templates/td-agent-confd/metrics.conf.j2", dest: "metrics.conf" }
   gather_facts: yes
   become: yes
 

--- a/provision/ansible/playbooks/roles/td-agent/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/td-agent/defaults/main.yml
@@ -8,4 +8,5 @@ tdagent_confd_templates: []
 td_agent_plugins:
   - { name: fluent-plugin-s3, version: 1.4.0 }
   - { name: fluent-plugin-azure-storage-append-blob, version: 0.2.1 }
+  - { name: fluent-plugin-prometheus, version: 1.8.5 }
 tdagent_forward_enabled: "{% if tdagent_confd_templates |length > 0 %}false{% else %}true{% endif %}"

--- a/provision/ansible/playbooks/templates/td-agent-confd/metrics.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/metrics.conf.j2
@@ -1,0 +1,21 @@
+# input plugin that exports metrics
+<source>
+  @type prometheus
+  bind 0.0.0.0
+  port 24231
+  metrics_path /metrics
+</source>
+
+<source>
+  @type monitor_agent
+  bind 0.0.0.0
+  port 24220
+</source>
+
+# input plugin that collects metrics from MonitorAgent
+<source>
+  @type prometheus_monitor
+  <labels>
+    host ${hostname}
+  </labels>
+</source>

--- a/provision/ansible/playbooks/templates/td-agent-confd/metrics.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/metrics.conf.j2
@@ -19,3 +19,19 @@
     host ${hostname}
   </labels>
 </source>
+
+# input plugin that collects metrics for output plugin
+<source>
+  @type prometheus_output_monitor
+  <labels>
+    host ${hostname}
+  </labels>
+</source>
+
+# input plugin that collects metrics for in_tail plugin
+<source>
+  @type prometheus_tail_monitor
+  <labels>
+    host ${hostname}
+  </labels>
+</source>

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-bastion.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-bastion.conf.j2
@@ -11,6 +11,20 @@
   </record>
 </filter>
 
+# count the number of incoming records per tag
+<filter **>
+  @type prometheus
+  <metric>
+    name fluentd_input_status_num_records_total
+    type counter
+    desc The total number of incoming records
+    <labels>
+      tag ${tag}
+      hostname ${hostname}
+    </labels>
+  </metric>
+</filter>
+
 <match **>
   @type forward
   send_timeout 60s

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-bastion.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-bastion.conf.j2
@@ -26,27 +26,44 @@
 </filter>
 
 <match **>
-  @type forward
-  send_timeout 60s
-  recover_wait 10s
-  hard_timeout 60s
+  @type copy
 
-  # Start up even if monitor host is not present
-  ignore_network_errors_at_startup true
+  <store>
+    @type forward
+    send_timeout 60s
+    recover_wait 10s
+    hard_timeout 60s
 
-  <server>
-    host {{ monitor_host }}
-  </server>
+    # Start up even if monitor host is not present
+    ignore_network_errors_at_startup true
 
-  <secondary>
-    @type file
-    path /var/log/td-agent/forward-failed
-  </secondary>
+    <server>
+      host {{ monitor_host }}
+    </server>
 
-  <buffer>
-    flush_mode interval
-    flush_interval 20s
-    flush_thread_count 8
-    chunk_limit_size 8M
-  </buffer>
+    <secondary>
+      @type file
+      path /var/log/td-agent/forward-failed
+    </secondary>
+
+    <buffer>
+      flush_mode interval
+      flush_interval 20s
+      flush_thread_count 8
+      chunk_limit_size 8M
+    </buffer>
+  </store>
+
+  <store>
+    @type prometheus
+    <metric>
+      name fluentd_output_status_num_records_total
+      type counter
+      desc The total number of outgoing records
+      <labels>
+        tag ${tag}
+        hostname ${hostname}
+      </labels>
+    </metric>
+  </store>
 </match>

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
@@ -40,27 +40,44 @@
 </filter>
 
 <match **>
-  @type forward
-  send_timeout 60s
-  recover_wait 10s
-  hard_timeout 60s
+  @type copy
 
-  # Start up even if monitor host is not present
-  ignore_network_errors_at_startup true
+  <store>
+    @type forward
+    send_timeout 60s
+    recover_wait 10s
+    hard_timeout 60s
 
-  <server>
-    host {{ monitor_host }}
-  </server>
+    # Start up even if monitor host is not present
+    ignore_network_errors_at_startup true
 
-  <secondary>
-    @type file
-    path /var/log/td-agent/forward-failed
-  </secondary>
+    <server>
+      host {{ monitor_host }}
+    </server>
 
-  <buffer>
-    flush_mode interval
-    flush_interval 20s
-    flush_thread_count 8
-    chunk_limit_size 8M
-  </buffer>
+    <secondary>
+      @type file
+      path /var/log/td-agent/forward-failed
+    </secondary>
+
+    <buffer>
+      flush_mode interval
+      flush_interval 20s
+      flush_thread_count 8
+      chunk_limit_size 8M
+    </buffer>
+  </store>
+
+  <store>
+    @type prometheus
+    <metric>
+      name fluentd_output_status_num_records_total
+      type counter
+      desc The total number of outgoing records
+      <labels>
+        tag ${tag}
+        hostname ${hostname}
+      </labels>
+    </metric>
+  </store>
 </match>

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-cassandra.conf.j2
@@ -25,6 +25,20 @@
   </record>
 </filter>
 
+# count the number of incoming records per tag
+<filter **>
+  @type prometheus
+  <metric>
+    name fluentd_input_status_num_records_total
+    type counter
+    desc The total number of incoming records
+    <labels>
+      tag ${tag}
+      hostname ${hostname}
+    </labels>
+  </metric>
+</filter>
+
 <match **>
   @type forward
   send_timeout 60s

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-docker.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-docker.conf.j2
@@ -17,6 +17,20 @@
   </record>
 </filter>
 
+# count the number of incoming records per tag
+<filter **>
+  @type prometheus
+  <metric>
+    name fluentd_input_status_num_records_total
+    type counter
+    desc The total number of incoming records
+    <labels>
+      tag ${tag}
+      hostname ${hostname}
+    </labels>
+  </metric>
+</filter>
+
 <match **>
   @type forward
   send_timeout 60s

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-docker.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-docker.conf.j2
@@ -32,27 +32,44 @@
 </filter>
 
 <match **>
-  @type forward
-  send_timeout 60s
-  recover_wait 10s
-  hard_timeout 60s
+  @type copy
 
-  # Start up even if monitor host is not present
-  ignore_network_errors_at_startup true
+  <store>
+    @type forward
+    send_timeout 60s
+    recover_wait 10s
+    hard_timeout 60s
 
-  <server>
-    host {{ monitor_host }}
-  </server>
+    # Start up even if monitor host is not present
+    ignore_network_errors_at_startup true
 
-  <secondary>
-    @type file
-    path /var/log/td-agent/forward-failed
-  </secondary>
+    <server>
+      host {{ monitor_host }}
+    </server>
 
-  <buffer>
-    flush_mode interval
-    flush_interval 20s
-    flush_thread_count 8
-    chunk_limit_size 8M
-  </buffer>
+    <secondary>
+      @type file
+      path /var/log/td-agent/forward-failed
+    </secondary>
+
+    <buffer>
+      flush_mode interval
+      flush_interval 20s
+      flush_thread_count 8
+      chunk_limit_size 8M
+    </buffer>
+  </store>
+
+  <store>
+    @type prometheus
+    <metric>
+      name fluentd_output_status_num_records_total
+      type counter
+      desc The total number of outgoing records
+      <labels>
+        tag ${tag}
+        hostname ${hostname}
+      </labels>
+    </metric>
+  </store>
 </match>

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
@@ -38,6 +38,21 @@
       hostname "#{Socket.gethostname}"
     </record>
   </filter>
+
+  # count the number of incoming records per tag
+  <filter **>
+    @type prometheus
+    <metric>
+      name fluentd_input_status_num_records_total
+      type counter
+      desc The total number of incoming records
+      <labels>
+        tag ${tag}
+        hostname ${hostname}
+      </labels>
+    </metric>
+  </filter>
+
   <match **>
     @type relabel
     @label @store

--- a/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
+++ b/provision/ansible/playbooks/templates/td-agent-confd/td-agent-monitor.conf.j2
@@ -77,6 +77,20 @@
         @type out_file
       </format>
     </store>
+
+    <store>
+      @type prometheus
+      <metric>
+        name fluentd_output_status_num_records_total
+        type counter
+        desc The total number of outgoing records
+        <labels>
+          tag ${tag}
+          hostname ${hostname}
+        </labels>
+      </metric>
+    </store>
+
 {% if storage_info|length > 1 and storage_info[0] == 'aws_s3' %}
     <store>
       @type s3


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-6482

* Added `fluent-plugin-prometheus` to `td-agent`.
* Added configuration to `td-agent` so that it can collect the number of input/output records. (https://docs.fluentd.org/monitoring-fluentd/monitoring-prometheus)
* Added `/metrics` endpoint on the port `24231` (the plugin's default number) to hosts where `td-agent` is installed.
* Added security groups and SRV records for Prometheus to get the metrics.
