### PR TITLE
Able to configure cluster accessibility for aks

### DIFF
--- a/modules/azure/kubernetes/kubernetes.tf
+++ b/modules/azure/kubernetes/kubernetes.tf
@@ -87,7 +87,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   dns_prefix              = local.kubernetes_cluster.dns_prefix
   kubernetes_version      = local.kubernetes_cluster.kubernetes_version
   node_resource_group     = "${local.kubernetes_cluster.resource_group_name}_MC"
-  private_cluster_enabled = true
+  private_cluster_enabled = ! local.kubernetes_cluster.public_cluster_enabled
 
   linux_profile {
     admin_username = local.kubernetes_cluster.admin_username

--- a/modules/azure/kubernetes/locals.tf
+++ b/modules/azure/kubernetes/locals.tf
@@ -32,6 +32,7 @@ locals {
     public_ssh_key_path       = var.network.public_key_path
     role_based_access_control = true
     kube_dashboard            = true
+    public_cluster_enabled    = false
     network_plugin            = "azure"
     load_balancer_sku         = "Standard"
     service_cidr              = cidrsubnet(var.network.cidr, 6, 12)


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-8250

# Done
- Add `public_cluster_enabled` var for configure cluster
- Fix to use `public_cluster_enabled` instead of `private_cluster_enabled`
`public_cluster_enabled` : `false` => `Private only`
`public_cluster_enabled` : `true` => `Public and Private`
https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#private_cluster_enabled
```
Should this Kubernetes Cluster have its API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to false. Changing this forces a new resource to be created.
```