### PR TITLE
Add cluster autoscaler for eks

### DIFF
--- a/modules/aws/kubernetes/autoscaler.tf
+++ b/modules/aws/kubernetes/autoscaler.tf
@@ -1,0 +1,27 @@
+provider "helm" {
+  kubernetes {
+    config_path = local.kubeconfig_name
+  }
+}
+
+module "cluster_autoscaler" {
+  source = "./autoscaler"
+
+  enabled                          = local.kubernetes_cluster.cluster_auto_scaling
+  cluster_name                     = aws_eks_cluster.eks_cluster.id
+  cluster_identity_oidc_issuer     = join("", aws_eks_cluster.eks_cluster.*.identity.0.oidc.0.issuer)
+  cluster_identity_oidc_issuer_arn = join("", aws_iam_openid_connect_provider.cluster_autoscaler.*.arn)
+  region                           = local.region
+}
+
+resource "aws_iam_openid_connect_provider" "cluster_autoscaler" {
+  count = local.kubernetes_cluster.cluster_auto_scaling ? 1 : 0
+
+  url = join("", aws_eks_cluster.eks_cluster.*.identity.0.oidc.0.issuer)
+
+  client_id_list = ["sts.amazonaws.com"]
+
+  # it's thumbprint won't change for many years
+  # https://github.com/terraform-providers/terraform-provider-aws/issues/10104
+  thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
+}

--- a/modules/aws/kubernetes/autoscaler.tf
+++ b/modules/aws/kubernetes/autoscaler.tf
@@ -22,7 +22,5 @@ resource "aws_iam_openid_connect_provider" "cluster_autoscaler" {
 
   client_id_list = ["sts.amazonaws.com"]
 
-  # it's thumbprint won't change for many years
-  # https://github.com/terraform-providers/terraform-provider-aws/issues/10104
   thumbprint_list = ["9e99a48a9960b14926bb7f3b02e22da2b0ab7280"]
 }

--- a/modules/aws/kubernetes/autoscaler.tf
+++ b/modules/aws/kubernetes/autoscaler.tf
@@ -12,6 +12,7 @@ module "cluster_autoscaler" {
   cluster_identity_oidc_issuer     = join("", aws_eks_cluster.eks_cluster.*.identity.0.oidc.0.issuer)
   cluster_identity_oidc_issuer_arn = join("", aws_iam_openid_connect_provider.cluster_autoscaler.*.arn)
   region                           = local.region
+  mod_depends_on                   = [local_file.kubeconfig]
 }
 
 resource "aws_iam_openid_connect_provider" "cluster_autoscaler" {

--- a/modules/aws/kubernetes/autoscaler/README.md
+++ b/modules/aws/kubernetes/autoscaler/README.md
@@ -1,0 +1,22 @@
+# autoscaler submodule of Kubernetes AWS module
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| cluster\_identity\_oidc\_issuer | The OIDC Identity issuer for the cluster | `string` | n/a | yes |
+| cluster\_identity\_oidc\_issuer\_arn | The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account | `string` | n/a | yes |
+| cluster\_name | The name of the cluster | `string` | n/a | yes |
+| enabled | Variable indicating whether deployment is enabled | `bool` | `false` | no |
+| helm\_chart\_name | Helm chart name to be installed | `string` | `"cluster-autoscaler-chart"` | no |
+| helm\_chart\_version | Version of the Helm chart | `string` | `"1.1.1"` | no |
+| helm\_release\_name | Helm release name | `string` | `"cluster-autoscaler"` | no |
+| helm\_repo\_url | Helm repository | `string` | `"https://kubernetes.github.io/autoscaler"` | no |
+| k8s\_service\_account\_name | The k8s cluster-autoscaler service account name | `string` | `"cluster-autoscaler"` | no |
+| mod\_depends\_on | List of references to other resources this submodule depends on | `any` | `null` | no |
+| region | The region | `string` | n/a | yes |
+| settings | Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler-chart | `map(any)` | `{}` | no |
+
+## Outputs
+
+No output.

--- a/modules/aws/kubernetes/autoscaler/iam.tf
+++ b/modules/aws/kubernetes/autoscaler/iam.tf
@@ -1,0 +1,69 @@
+data "aws_iam_policy_document" "cluster_autoscaler" {
+  count = var.enabled ? 1 : 0
+
+  statement {
+    sid = "Autoscaling"
+
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeTags",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "ec2:DescribeLaunchTemplateVersions"
+    ]
+
+    resources = ["*"]
+
+    effect = "Allow"
+  }
+
+}
+
+resource "aws_iam_policy" "cluster_autoscaler" {
+  count = var.enabled ? 1 : 0
+
+  name        = "${var.cluster_name}-cluster-autoscaler"
+  description = "Policy for cluster-autoscaler service"
+
+  policy = data.aws_iam_policy_document.cluster_autoscaler[0].json
+}
+
+data "aws_iam_policy_document" "cluster_autoscaler_assume" {
+  count = var.enabled ? 1 : 0
+
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.cluster_identity_oidc_issuer_arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(var.cluster_identity_oidc_issuer, "https://", "")}:sub"
+
+      values = [
+        "system:serviceaccount:kube-system:${var.k8s_service_account_name}",
+      ]
+    }
+
+    effect = "Allow"
+  }
+}
+
+resource "aws_iam_role" "cluster_autoscaler" {
+  count = var.enabled ? 1 : 0
+
+  name               = "${var.cluster_name}-cluster-autoscaler"
+  assume_role_policy = data.aws_iam_policy_document.cluster_autoscaler_assume[0].json
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_autoscaler" {
+  count = var.enabled ? 1 : 0
+
+  role       = aws_iam_role.cluster_autoscaler[0].name
+  policy_arn = aws_iam_policy.cluster_autoscaler[0].arn
+}

--- a/modules/aws/kubernetes/autoscaler/main.tf
+++ b/modules/aws/kubernetes/autoscaler/main.tf
@@ -1,0 +1,48 @@
+resource "helm_release" "cluster_autoscaler" {
+  count = var.enabled ? 1 : 0
+
+  chart      = var.helm_chart_name
+  namespace  = "kube-system"
+  name       = var.helm_release_name
+  version    = var.helm_chart_version
+  repository = var.helm_repo_url
+
+  set {
+    name  = "awsRegion"
+    value = var.region
+  }
+
+  set {
+    name  = "autoDiscovery.clusterName"
+    value = var.cluster_name
+  }
+
+  set {
+    name  = "rbac.create"
+    value = "true"
+  }
+
+  set {
+    name  = "rbac.serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "rbac.serviceAccount.name"
+    value = var.k8s_service_account_name
+  }
+
+  set {
+    name  = "rbac.serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = aws_iam_role.cluster_autoscaler[0].arn
+  }
+
+  dynamic "set" {
+    for_each = var.settings
+
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
+}

--- a/modules/aws/kubernetes/autoscaler/main.tf
+++ b/modules/aws/kubernetes/autoscaler/main.tf
@@ -45,4 +45,6 @@ resource "helm_release" "cluster_autoscaler" {
       value = set.value
     }
   }
+
+  depends_on = [var.mod_depends_on]
 }

--- a/modules/aws/kubernetes/autoscaler/vars.tf
+++ b/modules/aws/kubernetes/autoscaler/vars.tf
@@ -60,3 +60,9 @@ variable "settings" {
   default     = {}
   description = "Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler-chart"
 }
+
+variable "mod_depends_on" {
+  type        = any
+  default     = null
+  description = "List of references to other resources this submodule depends on"
+}

--- a/modules/aws/kubernetes/autoscaler/vars.tf
+++ b/modules/aws/kubernetes/autoscaler/vars.tf
@@ -24,8 +24,6 @@ variable "region" {
   description = "The region"
 }
 
-# cluster autoscaler
-
 variable "helm_chart_name" {
   type        = string
   default     = "cluster-autoscaler-chart"

--- a/modules/aws/kubernetes/autoscaler/vars.tf
+++ b/modules/aws/kubernetes/autoscaler/vars.tf
@@ -1,0 +1,62 @@
+variable "cluster_name" {
+  type        = string
+  description = "The name of the cluster"
+}
+
+variable "cluster_identity_oidc_issuer" {
+  type        = string
+  description = "The OIDC Identity issuer for the cluster"
+}
+
+variable "cluster_identity_oidc_issuer_arn" {
+  type        = string
+  description = "The OIDC Identity issuer ARN for the cluster that can be used to associate IAM roles with a service account"
+}
+
+variable "enabled" {
+  type        = bool
+  default     = false
+  description = "Variable indicating whether deployment is enabled"
+}
+
+variable "region" {
+  type        = string
+  description = "The region"
+}
+
+# cluster autoscaler
+
+variable "helm_chart_name" {
+  type        = string
+  default     = "cluster-autoscaler-chart"
+  description = "Helm chart name to be installed"
+}
+
+variable "helm_chart_version" {
+  type        = string
+  default     = "1.1.1"
+  description = "Version of the Helm chart"
+}
+
+variable "helm_release_name" {
+  type        = string
+  default     = "cluster-autoscaler"
+  description = "Helm release name"
+}
+
+variable "helm_repo_url" {
+  type        = string
+  default     = "https://kubernetes.github.io/autoscaler"
+  description = "Helm repository"
+}
+
+variable "k8s_service_account_name" {
+  default     = "cluster-autoscaler"
+  description = "The k8s cluster-autoscaler service account name"
+}
+
+variable "settings" {
+  type        = map(any)
+  default     = {}
+  description = "Additional settings which will be passed to the Helm chart values, see https://artifacthub.io/packages/helm/cluster-autoscaler/cluster-autoscaler-chart"
+}

--- a/modules/aws/kubernetes/locals.tf
+++ b/modules/aws/kubernetes/locals.tf
@@ -26,6 +26,7 @@ locals {
     cluster_encryption_config_enabled    = false
     cluster_encryption_config_resources  = ""
     cluster_encryption_config_kms_key_id = ""
+    cluster_auto_scaling                 = false
     aws_auth_system_master_role          = data.aws_iam_role.bastion.arn
     subnet_ids                           = concat(local.subnet_ids, local.public_subnet_ids, local.private_subnet_ids)
     use_fargate_profile                  = false

--- a/modules/aws/kubernetes/output.tf
+++ b/modules/aws/kubernetes/output.tf
@@ -7,3 +7,8 @@ output "config_map_aws_auth" {
   description = "A kubernetes configuration to authenticate to this EKS cluster."
   value       = kubernetes_config_map.aws_auth.*
 }
+
+output "kube_config_filename" {
+  description = "kubectl configuration filename"
+  value       = local.kubeconfig_name
+}

--- a/modules/aws/kubernetes/output.tf
+++ b/modules/aws/kubernetes/output.tf
@@ -7,8 +7,3 @@ output "config_map_aws_auth" {
   description = "A kubernetes configuration to authenticate to this EKS cluster."
   value       = kubernetes_config_map.aws_auth.*
 }
-
-output "kube_config_filename" {
-  description = "kubectl configuration filename"
-  value       = local.kubeconfig_name
-}


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-7887
https://docs.aws.amazon.com/ja_jp/eks/latest/userguide/cluster-autoscaler.html

Add cluster autoscaler for auto scaling in `EKS`
ref: https://github.com/lablabs/terraform-aws-eks-cluster-autoscaler

# Done
- Add autoscaler to eks with `helm_release`
- Default `cluster_auto_scaling` is `false`

📝 Just only suuport `cluster_endpoint_public_access` is `public` when first deploy