### PR TITLE
Fix deprecated property in azuread_application

### DIFF
--- a/modules/azure/kubernetes/kubernetes.tf
+++ b/modules/azure/kubernetes/kubernetes.tf
@@ -22,7 +22,7 @@ resource "random_id" "id" {
 
 # Create application for Service Principals
 resource "azuread_application" "app" {
-  name                       = "scalar-k8s-app-${local.network_name}-${random_id.id.b64_url}"
+  display_name               = "scalar-k8s-app-${local.network_name}-${random_id.id.b64_url}"
   homepage                   = "https://aks-${local.network_name}-${random_id.id.b64_url}"
   identifier_uris            = ["https://aks-${local.network_name}-${random_id.id.b64_url}"]
   reply_urls                 = ["https://aks-${local.network_name}-${random_id.id.b64_url}"]


### PR DESCRIPTION
# Description

Fix deprecated attribute name in `azuread_application`
https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application#display_name

```
Warning: Attribute is deprecated

  on .terraform/modules/kubernetes/modules/azure/kubernetes/kubernetes.tf line 25, in resource "azuread_application" "app":
  25:   name                       = "scalar-k8s-app-${local.network_name}-${random_id.id.b64_url}"

This property has been renamed to `display_name` and will be removed in
version 2.0 of this provider.
```