### PR TITLE
Remove unused mount point for tailon container

### DIFF
--- a/modules/universal/monitor/provision/docker-compose.yml
+++ b/modules/universal/monitor/provision/docker-compose.yml
@@ -63,7 +63,6 @@ services:
       - 8080:8080
     volumes:
       - /log:/log
-      - ./tailon/config.yaml:/tailon/config.yaml
     command:
       - "/usr/local/bin/tailon"
       - "-b"


### PR DESCRIPTION
A mount point for the config file of tailon container is not used since the file is not specified in the command line.