### PR TITLE
Fix scalardl instance size for aws chiku

### DIFF
--- a/modules/aws/scalardl/locals.tf
+++ b/modules/aws/scalardl/locals.tf
@@ -51,9 +51,7 @@ locals {
 
     bai = merge(local.scalardl_default, {})
 
-    chiku = merge(local.scalardl_default,
-      { resource_type = "t3.large" }
-    )
+    chiku = merge(local.scalardl_default, {})
 
     sho = merge(local.scalardl_default,
       { resource_type = "t3.large" }


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-7847

# Done

before(`t3.large`) -> after(`t3.medium`)
📝 `Standard_B2s` (2 vcpus, 4GB mem) = `t3.medium` (2 vcpus, 4GB mem)