### PR TITLE
Fix resource group not found issue

### DIFF
--- a/modules/azure/network/main.tf
+++ b/modules/azure/network/main.tf
@@ -10,7 +10,6 @@ resource "azurerm_resource_group" "resource_group" {
 }
 
 resource "azurerm_virtual_network" "vnet" {
-  depends_on          = [azurerm_resource_group.resource_group]
   name                = module.name_generator.name
   location            = var.region
   address_space       = [local.network.cidr]

--- a/modules/azure/network/main.tf
+++ b/modules/azure/network/main.tf
@@ -74,7 +74,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "dns_vnet_link" {
 module "bastion" {
   source = "./bastion"
 
-  network_name                  = module.name_generator.name
+  network_name                  = azurerm_resource_group.resource_group.name
   network_id                    = azurerm_virtual_network.vnet.id
   network_cidr                  = local.network.cidr
   network_dns                   = basename(azurerm_private_dns_zone.dns.id)


### PR DESCRIPTION
# Description

https://github.com/scalar-labs/scalar-terratest/runs/2050961182?check_suite_focus=true

```
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: Error: compute.AvailabilitySetsClient#CreateOrUpdate: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceGroupNotFound" Message="Resource group 'terratest-yhzcw4q' could not be found."
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: 
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158:   on .terraform/modules/network.bastion.bastion_cluster/main.tf line 236, in resource "azurerm_availability_set" "vm":
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158:  236: resource "azurerm_availability_set" "vm" {
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: 
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: 
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: 
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: Error: Error Creating/Updating Public IP "bastion-1-publicIP" (Resource Group "terratest-yhzcw4q"): network.PublicIPAddressesClient#CreateOrUpdate: Failure sending request: StatusCode=404 -- Original Error: Code="ResourceGroupNotFound" Message="Resource group 'terratest-yhzcw4q' could not be found."
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: 
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158:   on .terraform/modules/network.bastion.bastion_cluster/main.tf line 247, in resource "azurerm_public_ip" "vm":
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158:  247: resource "azurerm_public_ip" "vm" {
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: 
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: 
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: 
TestEndToEndTerraform 2021-03-07T15:21:08Z command.go:158: Error: Error creating/updating NSG "bastion-22-nsg" (Resource Group "terratest-yhzcw4q"): network.SecurityGroupsClient#CreateOrUpdate: Failure sending request: StatusCode=404 -- Original Error: Code="ResourceGroupNotFound" Message="Resource group 'terratest-yhzcw4q' could not be found."
```

# Done
- Fix to use `azurerm_resource_group.resource_group.name` instead of `module.name_generator.name` for create bastion cluster.
- Delete Unnecessary `depends_on`.