### PR TITLE
Update required Terraform version to 0.14 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Scalar Terraform is a set of terraform modules and provisioing scritps that can 
 
 ## Requirements
 
-* [Terraform >= 0.12.x](https://www.terraform.io/downloads.html)
+* [Terraform >= 0.14.x](https://www.terraform.io/downloads.html)
 * [Ansible >= 2.8.x](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
 * Cloud provider CLI tools such as `aws` and `az` (they need to be configured with credentials)
 * Docker Engine (with access to `ghcr.io/scalar-labs/scalar-ledger` docker registry)


### PR DESCRIPTION
The required Terraform version in the README is still 0.12 while the [Getting Started](https://github.com/scalar-labs/scalar-terraform/blob/97b2bb2f069e3694322607d89e35af2e832ae9a1/docs/GettingStarted.md) doc requests 0.14.