### PR TITLE
Fix Envoy auto_gen_cert script

### DIFF
--- a/modules/aws/scalardl/locals.tf
+++ b/modules/aws/scalardl/locals.tf
@@ -79,7 +79,7 @@ locals {
     tag                       = "v1.14.1"
     image                     = "envoyproxy/envoy"
     tls                       = false
-    cert_auto_gen             = true
+    cert_auto_gen             = false
     custom_config_path        = ""
   }
 }

--- a/modules/azure/scalardl/locals.tf
+++ b/modules/azure/scalardl/locals.tf
@@ -84,7 +84,7 @@ locals {
     tag                           = "v1.14.1"
     image                         = "envoyproxy/envoy"
     tls                           = false
-    cert_auto_gen                 = true
+    cert_auto_gen                 = false
     custom_config_path            = ""
     enable_accelerated_networking = false
   }

--- a/modules/universal/envoy/main.tf
+++ b/modules/universal/envoy/main.tf
@@ -98,12 +98,11 @@ resource "null_resource" "envoy_container" {
       "export internal_domain=${var.internal_domain}",
       "export envoy_tls=${var.envoy_tls}",
       "j2 ./envoy.yaml.j2 > ./envoy.yaml",
-      "echo export ENVOY_CERT_AUTO_GEN=${var.envoy_cert_auto_gen}",
+      "chmod 755 ./auto_gen_cert.sh",
+      "envoy_cert_auto_gen=${var.envoy_cert_auto_gen} ./auto_gen_cert.sh",
       "echo export ENVOY_IMAGE=${var.envoy_image} > env",
       "echo export ENVOY_TAG=${var.envoy_tag} >> env",
       "source ./env",
-      "chmod 755 ./auto_gen_cert.sh",
-      "./auto_gen_cert.sh",
       "docker-compose up -d",
     ]
   }

--- a/modules/universal/envoy/main.tf
+++ b/modules/universal/envoy/main.tf
@@ -99,7 +99,7 @@ resource "null_resource" "envoy_container" {
       "export envoy_tls=${var.envoy_tls}",
       "j2 ./envoy.yaml.j2 > ./envoy.yaml",
       "chmod 755 ./auto_gen_cert.sh",
-      "envoy_cert_auto_gen=${var.envoy_cert_auto_gen} ./auto_gen_cert.sh",
+      "[[ '${var.envoy_cert_auto_gen}' == 'true' ]] && ./auto_gen_cert.sh",
       "echo export ENVOY_IMAGE=${var.envoy_image} > env",
       "echo export ENVOY_TAG=${var.envoy_tag} >> env",
       "source ./env",

--- a/modules/universal/envoy/provision/auto_gen_cert.sh
+++ b/modules/universal/envoy/provision/auto_gen_cert.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-if [ "${envoy_cert_auto_gen}" = "true" ]; then
-  openssl req -x509 -nodes -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -subj '/CN=localhost';
-fi
+openssl req -x509 -nodes -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -subj '/CN=localhost';

--- a/modules/universal/envoy/vars.tf
+++ b/modules/universal/envoy/vars.tf
@@ -55,7 +55,7 @@ variable "envoy_tls" {
 }
 
 variable "envoy_cert_auto_gen" {
-  default     = true
+  default     = false
   description = "Flag to generate a self signed key and cert. Set to false to pass your own key and cert"
 }
 


### PR DESCRIPTION
This is the fix for the problem pointed out here. https://github.com/scalar-labs/scalar-terraform/pull/294#discussion_r595721629

Even though `envoy.cert_auto_gen` was set to `true` (it was the default), `auto_gen_cert.sh` was not working. And since the variable `envoy.tls` is `false` by default, running `auto_gen_cert.sh` by default didn't make sense. So I modified the default of that variable to `false`.
I wonder if this script is really needed because it creates a self-signed certificate, but this is the bugfix anyway.
