### PR TITLE
Fix test parttern to use regex for cassandra jvm.options

### DIFF
--- a/provision/ansible/playbooks/roles/goss/templates/config_validates/cassandra.yaml.j2
+++ b/provision/ansible/playbooks/roles/goss/templates/config_validates/cassandra.yaml.j2
@@ -10,9 +10,9 @@ file:
   /etc/cassandra/conf/jvm.options:
     exists: true
     contains:
-      - "-Xms{{$vars.jvm.xms}}"
-      - "-Xmx{{$vars.jvm.xmx}}"
-      - "-Xmn{{$vars.jvm.xmn}}"
+      - "/^-Xms{{$vars.jvm.xms}}$/"
+      - "/^-Xmx{{$vars.jvm.xmx}}$/"
+      - "/^-Xmn{{$vars.jvm.xmn}}$/"
 {% endraw %}
 {% for d in disk_io_devices %}
   /sys/block/{{ d }}/queue/nr_requests:


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-8770

# Done
`jvm.options` contains old commented out values, So fix to use `regex` .
```
#-Xms4G
#-Xmx4G
```