### PR TITLE
Add nr requests for azure cassandra

### DIFF
--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -15,6 +15,7 @@ cassandra_rack_id: rack1
 endpoint_snitch: GossipingPropertyFileSnitch
 vm_max_map_count: "1048575"
 
+# The scheduler should always be defined first.
 disk_io_params:
   - { name: scheduler, value: none }
   - { name: nr_requests, value: 256 }

--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -18,7 +18,7 @@ vm_max_map_count: "1048575"
 # The scheduler should always be defined first.
 disk_io_params:
   - { name: scheduler, value: none }
-  - { name: nr_requests, value: 256 }
+  - { name: nr_requests, value: 128 }
 
 # The following list of devices is for only Azure since the kernel parameters of AWS instances cannot be changed.
 disk_io_devices:

--- a/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/cassandra/defaults/main.yml
@@ -17,6 +17,7 @@ vm_max_map_count: "1048575"
 
 disk_io_params:
   - { name: scheduler, value: none }
+  - { name: nr_requests, value: 256 }
 
 # The following list of devices is for only Azure since the kernel parameters of AWS instances cannot be changed.
 disk_io_devices:

--- a/provision/ansible/playbooks/roles/goss/files/config_vars/azure_bai.yaml
+++ b/provision/ansible/playbooks/roles/goss/files/config_vars/azure_bai.yaml
@@ -13,9 +13,9 @@ cassandra:
     devices: "!sda, !xvda, !nvme0n1"
   # They are the default values since nr_requests in the Azure instances cannot be changed.
   nr_requests:
-    sda: 256
-    sdb: 256
-    sdc: 256
+    sda: 128
+    sdb: 128
+    sdc: 128
   scheduler:
     sda: none
     sdb: none

--- a/provision/ansible/playbooks/roles/goss/files/config_vars/azure_default.yaml
+++ b/provision/ansible/playbooks/roles/goss/files/config_vars/azure_default.yaml
@@ -13,9 +13,9 @@ cassandra:
     devices: "!sda, !xvda, !nvme0n1"
   # They are the default values since nr_requests in the Azure instances cannot be changed.
   nr_requests:
-    sda: 256
-    sdb: 256
-    sdc: 256
+    sda: 128
+    sdb: 128
+    sdc: 128
   scheduler:
     sda: none
     sdb: none


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-8764
https://scalar-labs.atlassian.net/browse/DLT-8766
https://scalar-labs.atlassian.net/browse/DLT-8775

When change only the `scheduler` value, nr_requests will also change to `2732`.

Workaround:
Just change `nr_requests` after changing `scheduler`.

# Done
Add `nr_requests` settings.
