### PR TITLE
Remove triggers of cassandra from scalardl module

### DIFF
--- a/modules/aws/cassandra/README.md
+++ b/modules/aws/cassandra/README.md
@@ -38,11 +38,9 @@ The Cassandra AWS module deploys a Cassandra cluster tuned for a Scalar DL envir
 | cassandra_host_ids | A list of host IDs for the Cassandra cluster. |
 | cassandra_host_ips | A list of host IP addresess for the Cassandra cluster. |
 | cassandra_hosts | A list of dns urls to access the Cassandra cluster. |
-| cassandra_provision_ids | The IDs of the provisioning step. |
 | cassandra_resource_count | The number of Cassandra nodes to create. |
 | cassandra_security_ids | The security group IDs of the Cassandra cluster. |
 | cassandra_seed_ips | A list of host IP addresess for the Cassandra seeds. |
-| cassandra_start_on_initial_boot | A flag to start Cassandra or not on the initial boot. |
 | inventory_ini | The inventory file for Ansible. |
 | network_interface_ids | A list of primary interface IDs for the Cassandra cluster. |
 

--- a/modules/aws/cassandra/output.tf
+++ b/modules/aws/cassandra/output.tf
@@ -1,8 +1,3 @@
-output "cassandra_provision_ids" {
-  value       = module.cassandra_provision.provision_ids
-  description = "The IDs of the provisioning step."
-}
-
 output "cassandra_host_ips" {
   value       = module.cassandra_cluster.private_ip
   description = "A list of host IP addresess for the Cassandra cluster."
@@ -36,11 +31,6 @@ output "network_interface_ids" {
 output "cassandra_resource_count" {
   value       = local.cassandra.resource_count
   description = "The number of Cassandra nodes to create."
-}
-
-output "cassandra_start_on_initial_boot" {
-  value       = local.cassandra.start_on_initial_boot
-  description = "A flag to start Cassandra or not on the initial boot."
 }
 
 output "inventory_ini" {

--- a/modules/aws/scalardl/cluster/README.md
+++ b/modules/aws/scalardl/cluster/README.md
@@ -30,7 +30,6 @@ The Cluster module deploys a Scalar DL cluster.
 | custom_tags | The map of custom tags | `map(string)` | `{}` | no |
 | enable_tdagent | A flag to install td-agent that forwards logs to the monitor host | `bool` | `true` | no |
 | security_group_ids | A list of security groups to attach to resources | `list(string)` | `[]` | no |
-| triggers | A trigger key that will initiate provisioning of scalardl resource | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/aws/scalardl/cluster/main.tf
+++ b/modules/aws/scalardl/cluster/main.tf
@@ -45,7 +45,6 @@ module "scalardl_cluster" {
 module "scalardl_provision" {
   source           = "../../../universal/scalardl"
   vm_ids           = module.scalardl_cluster.id
-  triggers         = var.triggers
   bastion_host_ip  = var.bastion_ip
   host_list        = module.scalardl_cluster.private_ip
   user_name        = var.user_name

--- a/modules/aws/scalardl/cluster/vars.tf
+++ b/modules/aws/scalardl/cluster/vars.tf
@@ -34,12 +34,6 @@ variable "resource_root_volume_size" {
   description = "The size of resource root volume size"
 }
 
-variable "triggers" {
-  type        = list(string)
-  default     = []
-  description = "A trigger key that will initiate provisioning of scalardl resource"
-}
-
 variable "private_key_path" {
   type        = string
   description = "The path to the private key for SSH access"

--- a/modules/aws/scalardl/envoy.tf
+++ b/modules/aws/scalardl/envoy.tf
@@ -43,7 +43,6 @@ module "envoy_cluster" {
 module "envoy_provision" {
   source              = "../../universal/envoy"
   vm_ids              = module.envoy_cluster.id
-  triggers            = local.triggers
   bastion_host_ip     = local.bastion_ip
   host_list           = module.envoy_cluster.private_ip
   user_name           = local.user_name

--- a/modules/aws/scalardl/locals.tf
+++ b/modules/aws/scalardl/locals.tf
@@ -108,12 +108,6 @@ locals {
 }
 
 locals {
-  triggers = [
-    local.scalardl.database == "cassandra" && var.cassandra.start_on_initial_boot ? var.cassandra.provision_ids : var.network.bastion_provision_id
-  ]
-}
-
-locals {
   inventory = <<EOF
 [scalardl]
 %{for f in aws_route53_record.scalardl_blue_dns.*.fqdn~}

--- a/modules/aws/scalardl/scalardl.tf
+++ b/modules/aws/scalardl/scalardl.tf
@@ -8,7 +8,6 @@ module "scalardl_blue" {
   resource_count               = local.scalardl.blue_resource_count
   resource_cluster_name        = "blue"
   resource_root_volume_size    = local.scalardl.resource_root_volume_size
-  triggers                     = local.triggers
   private_key_path             = local.private_key_path
   user_name                    = local.user_name
   subnet_ids                   = local.blue_subnet_ids
@@ -38,7 +37,6 @@ module "scalardl_green" {
   resource_count               = local.scalardl.green_resource_count
   resource_cluster_name        = "green"
   resource_root_volume_size    = local.scalardl.resource_root_volume_size
-  triggers                     = local.triggers
   private_key_path             = local.private_key_path
   user_name                    = local.user_name
   subnet_ids                   = local.green_subnet_ids

--- a/modules/aws/scalardl/vars.tf
+++ b/modules/aws/scalardl/vars.tf
@@ -9,11 +9,6 @@ variable "network" {
   description = "The network settings of a scalardl cluster"
 }
 
-variable "cassandra" {
-  type        = map(string)
-  description = "The provisioning settings of a cassandra cluster"
-}
-
 variable "scalardl" {
   type        = map(string)
   default     = {}

--- a/modules/azure/cassandra/README.md
+++ b/modules/azure/cassandra/README.md
@@ -37,10 +37,8 @@ The Cassandra Azure module deploys a Cassandra cluster tuned for a Scalar DL env
 |------|-------------|
 | cassandra_host_ids | A list of host IDs for the Cassandra cluster. |
 | cassandra_host_ips | A list of host IP addresess for the Cassandra cluster. |
-| cassandra_provision_ids | The IDs of the provisioning step. |
 | cassandra_resource_count | The number of Cassandra nodes to create. |
 | cassandra_seed_ips | A list of host IP addresess for the Cassandra seeds. |
-| cassandra_start_on_initial_boot | A flag to start Cassandra or not on the initial boot. |
 | inventory_ini | The inventory file for Ansible. |
 | network_interface_ids | A list of network interface IDs for the Cassandra cluster. |
 

--- a/modules/azure/cassandra/output.tf
+++ b/modules/azure/cassandra/output.tf
@@ -1,8 +1,3 @@
-output "cassandra_provision_ids" {
-  value       = module.cassandra_provision.provision_ids
-  description = "The IDs of the provisioning step."
-}
-
 output "cassandra_host_ips" {
   value       = module.cassandra_cluster.network_interface_private_ip
   description = "A list of host IP addresess for the Cassandra cluster."
@@ -26,11 +21,6 @@ output "network_interface_ids" {
 output "cassandra_resource_count" {
   value       = local.cassandra.resource_count
   description = "The number of Cassandra nodes to create."
-}
-
-output "cassandra_start_on_initial_boot" {
-  value       = local.cassandra.start_on_initial_boot
-  description = "A flag to start Cassandra or not on the initial boot."
 }
 
 output "inventory_ini" {

--- a/modules/azure/scalardl/cluster/README.md
+++ b/modules/azure/scalardl/cluster/README.md
@@ -33,7 +33,6 @@ The Cluster module deploys a Scalar DL cluster on Azure.
 | cassandra_replication_factor | The replication factor for the Cassandra schema | `number` | `3` | no |
 | enable_accelerated_networking | A flag to enable accelerated networking on network interface | `bool` | `false` | no |
 | enable_tdagent | A flag to install td-agent that forwards logs to the monitor host | `bool` | `true` | no |
-| triggers | A trigger key that will initiate provisioning of scalardl resource | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/azure/scalardl/cluster/main.tf
+++ b/modules/azure/scalardl/cluster/main.tf
@@ -23,7 +23,6 @@ module "scalardl_provision" {
   source = "../../../universal/scalardl"
 
   vm_ids           = module.cluster.vm_ids
-  triggers         = var.triggers
   bastion_host_ip  = var.bastion_ip
   host_list        = module.cluster.network_interface_private_ip
   user_name        = var.user_name

--- a/modules/azure/scalardl/cluster/vars.tf
+++ b/modules/azure/scalardl/cluster/vars.tf
@@ -38,12 +38,6 @@ variable "resource_root_volume_size" {
   description = "The size of resource root volume size"
 }
 
-variable "triggers" {
-  type        = list(string)
-  default     = []
-  description = "A trigger key that will initiate provisioning of scalardl resource"
-}
-
 variable "private_key_path" {
   type        = string
   description = "The path to the private key for SSH access"

--- a/modules/azure/scalardl/envoy.tf
+++ b/modules/azure/scalardl/envoy.tf
@@ -29,7 +29,6 @@ module "envoy_provision" {
   source = "../../universal/envoy"
 
   vm_ids              = module.envoy_cluster.vm_ids
-  triggers            = local.triggers
   bastion_host_ip     = local.bastion_ip
   host_list           = module.envoy_cluster.network_interface_private_ip
   user_name           = local.user_name

--- a/modules/azure/scalardl/locals.tf
+++ b/modules/azure/scalardl/locals.tf
@@ -12,10 +12,6 @@ locals {
   public_key_path  = var.network.public_key_path
   user_name        = var.network.user_name
   internal_domain  = var.network.internal_domain
-
-  triggers = [
-    local.scalardl.database == "cassandra" && var.cassandra.start_on_initial_boot ? var.cassandra.provision_ids : var.network.bastion_provision_id
-  ]
 }
 
 ### default

--- a/modules/azure/scalardl/scalardl.tf
+++ b/modules/azure/scalardl/scalardl.tf
@@ -14,7 +14,6 @@ module "scalardl_blue" {
   resource_count                = local.scalardl.blue_resource_count
   resource_cluster_name         = "blue"
   resource_root_volume_size     = local.scalardl.resource_root_volume_size
-  triggers                      = local.triggers
   region                        = local.region
   locations                     = local.locations
   private_key_path              = local.private_key_path
@@ -47,7 +46,6 @@ module "scalardl_green" {
   resource_count                = local.scalardl.green_resource_count
   resource_cluster_name         = "green"
   resource_root_volume_size     = local.scalardl.resource_root_volume_size
-  triggers                      = local.triggers
   region                        = local.region
   locations                     = local.locations
   private_key_path              = local.private_key_path

--- a/modules/azure/scalardl/vars.tf
+++ b/modules/azure/scalardl/vars.tf
@@ -9,11 +9,6 @@ variable "network" {
   description = "The network settings of a scalardl cluster"
 }
 
-variable "cassandra" {
-  type        = map(string)
-  description = "The provisioning settings of a cassandra cluster"
-}
-
 variable "scalardl" {
   type        = map(string)
   default     = {}

--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -14,7 +14,6 @@ resource "null_resource" "scalardl_image" {
 
   triggers = {
     scalar_tag = var.scalardl_image_tag
-    triggers   = join(",", var.triggers)
   }
 
   provisioner "local-exec" {
@@ -48,7 +47,6 @@ resource "null_resource" "schema_loader_image" {
   count = var.provision_count > 0 ? 1 : 0
 
   triggers = {
-    triggers            = join(",", var.triggers)
     schema_loader_image = var.schema_loader_image
   }
 
@@ -63,7 +61,6 @@ resource "null_resource" "scalardl_waitfor" {
   count = var.provision_count
 
   triggers = {
-    triggers = join(",", var.triggers)
     vm_id    = var.vm_ids[count.index]
   }
 

--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -61,7 +61,7 @@ resource "null_resource" "scalardl_waitfor" {
   count = var.provision_count
 
   triggers = {
-    vm_id    = var.vm_ids[count.index]
+    vm_id = var.vm_ids[count.index]
   }
 
   connection {

--- a/modules/universal/scalardl/vars.tf
+++ b/modules/universal/scalardl/vars.tf
@@ -10,11 +10,6 @@ variable "user_name" {
   description = "The user of the remote instance to provision"
 }
 
-variable "triggers" {
-  description = "A trigger to initiate provisioning"
-  default     = []
-}
-
 variable "vm_ids" {
   default     = []
   description = "A list of virtual machine IDs to provision"


### PR DESCRIPTION
https://scalar-labs.atlassian.net/browse/DLT-8836

The triggers for `null_resource` resources in the scalardl module are no longer needed. Accordingly, the outputs from the cassandra module are also removed.
