### PR TITLE
Update readme for scalardl module

### DIFF
--- a/modules/aws/scalardl/README.md
+++ b/modules/aws/scalardl/README.md
@@ -23,7 +23,6 @@ The Scalar DL module deploys a scalardl resource cluster using blue/green deploy
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cassandra | The provisioning settings of a cassandra cluster | `map(string)` | n/a | yes |
 | network | The network settings of a scalardl cluster | `map(string)` | n/a | yes |
 | base | The base of a scalardl cluster | `string` | `"default"` | no |
 | custom_tags | The map of custom tags | `map(string)` | `{}` | no |

--- a/modules/azure/scalardl/README.md
+++ b/modules/azure/scalardl/README.md
@@ -24,7 +24,6 @@ The Scalar DL module deploys a scalardl resource cluster using blue/green deploy
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cassandra | The provisioning settings of a cassandra cluster | `map(string)` | n/a | yes |
 | network | The network settings of a scalardl cluster | `map(string)` | n/a | yes |
 | base | The base of a scalardl cluster | `string` | `"default"` | no |
 | envoy | The custom settings of an envoy cluster | `map(string)` | `{}` | no |


### PR DESCRIPTION
# Description

The input variable `cassandra` map is no longer needed.
Update readme for PR #303 