### PR TITLE
Fix the schema-loading command for Cosmos DB

### DIFF
--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -212,9 +212,9 @@ resource "null_resource" "scalardl_schema" {
       "set -x",
       # Get the SCALAR_DB_* variables from the env file for docker-compose
       "eval `grep '^SCALAR_DB_' $HOME/provision/container.env`",
-      "cmd=\"docker run --rm ${var.schema_loader_image} -u $SCALAR_DB_USERNAME -p $SCALAR_DB_PASSWORD\"",
-      "if [ $SCALAR_DB_STORAGE = 'cassandra' ]; then $cmd --cassandra -h $SCALAR_DB_CONTACT_POINTS -P $SCALAR_DB_CONTACT_PORT -n NetworkTopologyStrategy -R ${var.cassandra_replication_factor};",
-      "elif [ $SCALAR_DB_STORAGE = 'dynamo' ]; then $cmd --dynamo --region $SCALAR_DB_CONTACT_POINTS;",
+      "cmd=\"docker run --rm ${var.schema_loader_image} -p $SCALAR_DB_PASSWORD\"",
+      "if [ $SCALAR_DB_STORAGE = 'cassandra' ]; then $cmd --cassandra -u $SCALAR_DB_USERNAME -h $SCALAR_DB_CONTACT_POINTS -P $SCALAR_DB_CONTACT_PORT -n NetworkTopologyStrategy -R ${var.cassandra_replication_factor};",
+      "elif [ $SCALAR_DB_STORAGE = 'dynamo' ]; then $cmd --dynamo -u $SCALAR_DB_USERNAME --region $SCALAR_DB_CONTACT_POINTS;",
       "elif [ $SCALAR_DB_STORAGE = 'cosmos' ]; then $cmd --cosmos -h $SCALAR_DB_CONTACT_POINTS;",
       "else /bin/false;",
       "fi"


### PR DESCRIPTION
When we use Cosmos DB, `SCALAR_DB_USERNAME` is not used but the option `-u` was specified in the schema loading command.

If we use a `scalardl_conatainer.env` like below with an empty `SCALAR_DB_USERNAME=` line,
```
SCALAR_DB_STORAGE=cosmos
SCALAR_DB_CONTACT_POINTS=https://xxxxx-cosmosdb.documents.azure.com:443/
SCALAR_DB_CONTACT_PORT=
SCALAR_DB_USERNAME=
SCALAR_DB_PASSWORD=the-cosmos-db-key
```
the following command is run and it fails due to no argument for `-u`.
```
docker run --rm ghcr.io/scalar-labs/scalardl-schema-loader:1.3.0 -u -p the-cosmos-db-key --cosmos -h https://xxxxx-cosmosdb.documents.azure.com:443/
Exception in thread "main" java.lang.NullPointerException: 'key' cannot be null.
...
```

[As we discussed](https://github.com/scalar-labs/scalar-terraform/pull/293#discussion_r611266780), we need to consider refactoring the schema loading part, but this is a quick fix.
