### PR TITLE
Update Scalar DL node replacement command

### DIFF
--- a/docs/NodeReplacement.md
+++ b/docs/NodeReplacement.md
@@ -28,8 +28,12 @@ module.network.module.bastion.module.bastion_provision.null_resource.ansible_pla
 ```
 # AWS
 module.scalardl.module.scalardl_blue.module.scalardl_cluster.aws_instance.this[0]
+module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.schema_loader_image[0]
+module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_image[0]
 # Azure
 module.scalardl.module.scalardl_blue.module.cluster.azurerm_virtual_machine.vm-linux[0]
+module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.schema_loader_image[0]
+module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_image[0]
 ```
 
 * The index for `aws_instance.this` or `azurerm_virtual_machine.vm-linux` should be changed according to the node you want to replace.


### PR DESCRIPTION
Based on NodeReplacement doc, Scalar DL node replacement failed in both AWS and Azure PSIM environments.

```
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_load[0] (remote-exec): 52d41b419360: Loading layer  5.632kB/5.632kB
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_load[0] (remote-exec): 


module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_load[0] (remote-exec): 2e790ed37b7e: Loading layer  3.072kB/3.072kB
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_load[0] (remote-exec): 
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_load[0] (remote-exec): Loaded image: ghcr.io/scalar-labs/scalar-ledger:2.1.0
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_load[0]: Still creating... [1m10s elapsed]
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.scalardl_load[0]: Creation complete after 1m10s [id=1314021266399735200]

Error: stat .terraform/modules/scalardl/modules/universal/scalardl/scalardl-schema-loader-1.2.0.tar.gz: no such file or directory
```

Ref:- https://scalar-labs.atlassian.net/browse/DLT-8757
https://scalar-labs.atlassian.net/browse/DLT-8735