### PR TITLE
Add file check for create scalardl image file

### DIFF
--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -10,7 +10,7 @@ module "ansible" {
 }
 
 resource "null_resource" "scalardl_image" {
-  count = var.provision_count > 0 ? 1 : 0
+  count = var.provision_count > 0 && !fileexists("${path.module}/${local.image_filename}") ? 1 : 0
 
   triggers = {
     scalar_tag = var.scalardl_image_tag
@@ -44,7 +44,7 @@ resource "null_resource" "scalardl_image_push" {
 }
 
 resource "null_resource" "schema_loader_image" {
-  count = var.provision_count > 0 ? 1 : 0
+  count = var.provision_count > 0 && !fileexists("${path.module}/${local.schema_loader_image_filename}") ? 1 : 0
 
   triggers = {
     schema_loader_image = var.schema_loader_image

--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -57,6 +57,26 @@ resource "null_resource" "schema_loader_image" {
   }
 }
 
+resource "null_resource" "schema_loader_image_push" {
+  count = var.provision_count > 0 ? 1 : 0
+
+  triggers = {
+    docker_image = null_resource.schema_loader_image[0].id
+  }
+
+  connection {
+    host        = var.bastion_host_ip
+    user        = var.user_name
+    agent       = true
+    private_key = file(var.private_key_path)
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/${local.schema_loader_image_filename}"
+    destination = "${module.ansible.remote_playbook_path}/${local.schema_loader_image_filename}"
+  }
+}
+
 resource "null_resource" "scalardl_waitfor" {
   count = var.provision_count
 
@@ -144,6 +164,26 @@ resource "null_resource" "scalardl_load" {
   }
 }
 
+resource "null_resource" "schema_loader_push" {
+  count = var.provision_count > 0 ? 1 : 0
+
+  triggers = {
+    triggers     = null_resource.docker_install[count.index].id,
+    scalar_image = null_resource.schema_loader_image_push[0].id
+  }
+
+  connection {
+    host        = var.bastion_host_ip
+    user        = var.user_name
+    agent       = true
+    private_key = file(var.private_key_path)
+  }
+
+  provisioner "remote-exec" {
+    inline = ["rsync -e 'ssh -o StrictHostKeyChecking=no' -cvv ${module.ansible.remote_playbook_path}/${local.schema_loader_image_filename} ${var.user_name}@${var.host_list[count.index]}:/tmp/"]
+  }
+}
+
 resource "null_resource" "schema_loader_image_load" {
   count = var.provision_count > 0 ? 1 : 0
 
@@ -158,11 +198,6 @@ resource "null_resource" "schema_loader_image_load" {
     user         = var.user_name
     agent        = true
     private_key  = file(var.private_key_path)
-  }
-
-  provisioner "file" {
-    source      = "${path.module}/${local.schema_loader_image_filename}"
-    destination = "/tmp/${local.schema_loader_image_filename}"
   }
 
   provisioner "remote-exec" {


### PR DESCRIPTION
# Description

Errors occur when running `taint` on a different machine than the one used to build the environment.

ref: #306