### PR TITLE
Update troubleshooting guide

### DIFF
--- a/docs/TroubleshootingGuide.md
+++ b/docs/TroubleshootingGuide.md
@@ -24,7 +24,7 @@ terraform state rm "module.cassandra.azurerm_virtual_machine_data_disk_attachmen
 ```
 * Do `terraform apply`
 
-Follow [Cassandra Post Recovery Steps](CassandraOperation.md#post-terraform-steps)
+Follow [Cassandra Post Terraform Steps](CassandraOperation.md#post-terraform-steps)
 
 ### Recover a node with data disk from accidental deletion of a node and data disk in Azure
 If you accidentally delete a node and data disk in Azure, you can recover that node and data disk using the following steps.
@@ -39,6 +39,6 @@ terraform state rm "module.cassandra.azurerm_managed_disk.cassandra_data_volume[
 ```
 * Do `terraform apply`
 
-Follow [Cassandra Post Recovery Steps](CassandraOperation.md#post-terraform-steps-2)
+Follow [Cassandra Post Terraform Steps](CassandraOperation.md#post-terraform-steps-2)
 
 

--- a/docs/TroubleshootingGuide.md
+++ b/docs/TroubleshootingGuide.md
@@ -17,12 +17,28 @@ If you accidentally delete a node that contains an additional data disk in Azure
 
 Please try the following
 * Delete the os-disk If the node is terminated.
-* Do `terraform refresh` or `terraform state rm` as follows.
+* Do `terraform state rm` as follows.
 ```console
 terraform state rm "module.cassandra.module.cassandra_cluster.azurerm_virtual_machine.vm-linux[0]"
 terraform state rm "module.cassandra.azurerm_virtual_machine_data_disk_attachment.cassandra_data_volume_attachment[0]"
 ```
 * Do `terraform apply`
 
-Follow [Cassandra Post Recovery Steps](CassandraOperation.md#post-recovery-steps)
+Follow [Cassandra Post Recovery Steps](CassandraOperation.md#post-terraform-steps)
+
+### Recover a node with data disk from accidental deletion of a node and data disk in Azure
+If you accidentally delete a node and data disk in Azure, you can recover that node and data disk using the following steps.
+
+Please try the following
+* Delete the os-disk If the node is terminated.
+* Do `terraform state rm` as follows.
+```console
+terraform state rm "module.cassandra.module.cassandra_cluster.azurerm_virtual_machine.vm-linux[0]"
+terraform state rm "module.cassandra.azurerm_virtual_machine_data_disk_attachment.cassandra_data_volume_attachment[0]"
+terraform state rm "module.cassandra.azurerm_managed_disk.cassandra_data_volume[0]"
+```
+* Do `terraform apply`
+
+Follow [Cassandra Post Recovery Steps](CassandraOperation.md#post-terraform-steps-2)
+
 

--- a/docs/TroubleshootingGuide.md
+++ b/docs/TroubleshootingGuide.md
@@ -8,14 +8,12 @@ When you accidentally delete a resource manually without terraform, it causes so
 ### Recover from accidental deletion of a node in Azure
 If you accidentally delete a node that does not have an additional data disk in Azure, you can recover it in the following steps. It is mainly applicable for scalardl, envoy, cassy, reaper, monitor and ca nodes.
 
-Please try the following
 * Delete the os-disk If the node is terminated.
 * Follow [Node Replacement](NodeReplacement.md)
 
 ### Recover a node with existing data disk from accidental deletion of a node in Azure
 If you accidentally delete a node that contains an additional data disk in Azure, you can recover that node with an existing data disk using the following steps.
 
-Please try the following
 * Delete the os-disk If the node is terminated.
 * Do `terraform state rm` as follows.
 ```console
@@ -26,10 +24,9 @@ terraform state rm "module.cassandra.azurerm_virtual_machine_data_disk_attachmen
 
 Follow [Cassandra Post Terraform Steps](CassandraOperation.md#post-terraform-steps)
 
-### Recover a node with data disk from accidental deletion of a node and data disk in Azure
+### Recover a node with a data disk from accidental deletion of both the node and the data disk in Azure
 If you accidentally delete a node and data disk in Azure, you can recover that node and data disk using the following steps.
 
-Please try the following
 * Delete the os-disk If the node is terminated.
 * Do `terraform state rm` as follows.
 ```console


### PR DESCRIPTION
Update troubleshooting guide

* `terraform refresh` shows the following error
```
module.cassandra.azurerm_virtual_machine_data_disk_attachment.cassandra_data_volume_attachment[0]: Refreshing state... [id=/subscriptions/b647bf0e-0566-4b28-ac8c-37b24f3b7061/resourceGroups/psim-azure-hvidlnk/providers/Microsoft.Compute/virtualMachines/cassandra-1/dataDisks/data-disk-cassandra0]
module.cassandra.azurerm_virtual_machine_data_disk_attachment.cassandra_data_volume_attachment[2]: Refreshing state... [id=/subscriptions/b647bf0e-0566-4b28-ac8c-37b24f3b7061/resourceGroups/psim-azure-hvidlnk/providers/Microsoft.Compute/virtualMachines/cassandra-3/dataDisks/data-disk-cassandra2]
module.cassandra.azurerm_virtual_machine_data_disk_attachment.cassandra_data_volume_attachment[1]: Refreshing state... [id=/subscriptions/b647bf0e-0566-4b28-ac8c-37b24f3b7061/resourceGroups/psim-azure-hvidlnk/providers/Microsoft.Compute/virtualMachines/cassandra-2/dataDisks/data-disk-cassandra1]
module.cassandra.module.cassandra_provision.null_resource.cassandra[2]: Refreshing state... [id=196610524335755786]
module.cassandra.module.cassandra_provision.null_resource.cassandra[0]: Refreshing state... [id=7697572524007658753]
module.cassandra.module.cassandra_provision.null_resource.cassandra[1]: Refreshing state... [id=3515917159123694899]

Error: Virtual Machine "cassandra-1" (Resource Group "psim-azure-hvidlnk") was not found


Releasing state lock. This may take a few moments...
```

* Node with data disk recovery also failed while using the following commands
```
terraform taint "module.cassandra.module.cassandra_cluster.azurerm_virtual_machine.vm-linux[0]"
terraform taint "module.cassandra.azurerm_managed_disk.cassandra_data_volume[0]"

terraform apply
```