### PR TITLE
Fix logrotate issue in monitor server

### DIFF
--- a/provision/ansible/playbooks/roles/td-agent_aggregation/templates/monitor.logrotate.j2
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/templates/monitor.logrotate.j2
@@ -2,6 +2,7 @@
 {
   daily
   rotate {{ log_retention_period_days }}
+  size 0
   missingok
   compress
   dateext

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/templates/monitor.logrotate.j2
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/templates/monitor.logrotate.j2
@@ -2,7 +2,7 @@
 {
   daily
   rotate {{ log_retention_period_days }}
-  size 0
+  minsize 0
   missingok
   compress
   dateext


### PR DESCRIPTION
# Description

Logrotate doesn't rotate well
```
[root@monitor-1 logrotate.d]# /usr/sbin/logrotate -dv /etc/logrotate.d/monitor
reading config file /etc/logrotate.d/monitor
Allocating hash table for state file, size 15360 B

Handling 1 logs

rotating pattern: /log/**/*.log
 after 1 days (30 rotations)
empty log files are rotated, old logs are removed
considering log /log/bastion-1/fluent.log
  log does not need rotating (log has been already rotated)considering log /log/bastion-1/system.log
  log does not need rotating (log has been already rotated)considering log /log/cassandra-1/cassandra.log
```

The reason is that the fluent log is smaller than 1M(default size) , So all logs are considered unnecessary to rotate.
```
[root@monitor-1 bastion-1]# ls -llhta
total 205M
-rw-r--r--.  1 td-agent td-agent 204M May  6 02:42 system.log
-rw-r--r--.  1 td-agent td-agent  37K May  5 03:12 fluent.log
drwxr-xr-x. 16 td-agent td-agent  256 Jan 21 12:27 ..
drwxr-xr-x.  2 td-agent td-agent   42 Jan 19 04:48 .
```

# Done
Fix to always rotate daily.