### PR TITLE
Fix to copy schema loader image via bastion

### DIFF
--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -47,8 +47,7 @@ resource "null_resource" "schema_loader_image" {
   count = var.provision_count > 0 ? 1 : 0
 
   triggers = {
-    schema_loader_image = var.schema_loader_image,
-    triggers            = null_resource.docker_install[0].id
+    schema_loader_image = var.schema_loader_image
   }
 
   provisioner "local-exec" {

--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -47,7 +47,8 @@ resource "null_resource" "schema_loader_image" {
   count = var.provision_count > 0 ? 1 : 0
 
   triggers = {
-    schema_loader_image = var.schema_loader_image
+    schema_loader_image = var.schema_loader_image,
+    triggers            = null_resource.docker_install[count.index].id
   }
 
   provisioner "local-exec" {
@@ -189,7 +190,7 @@ resource "null_resource" "schema_loader_image_load" {
 
   triggers = {
     triggers     = null_resource.docker_install[0].id,
-    scalar_image = null_resource.schema_loader_image[0].id
+    scalar_image = null_resource.schema_loader_push[0].id
   }
 
   connection {

--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -57,6 +57,26 @@ resource "null_resource" "schema_loader_image" {
   }
 }
 
+resource "null_resource" "schema_loader_image_push" {
+  count = var.provision_count > 0 ? 1 : 0
+
+  triggers = {
+    docker_image = null_resource.schema_loader_image[0].id
+  }
+
+  connection {
+    host        = var.bastion_host_ip
+    user        = var.user_name
+    agent       = true
+    private_key = file(var.private_key_path)
+  }
+
+  provisioner "file" {
+    source      = "${path.module}/${local.schema_loader_image_filename}"
+    destination = "${module.ansible.remote_playbook_path}/${local.schema_loader_image_filename}"
+  }
+}
+
 resource "null_resource" "scalardl_waitfor" {
   count = var.provision_count
 
@@ -144,6 +164,26 @@ resource "null_resource" "scalardl_load" {
   }
 }
 
+resource "null_resource" "schema_loader_push" {
+  count = var.provision_count > 0 ? 1 : 0
+
+  triggers = {
+    triggers     = null_resource.docker_install[count.index].id,
+    scalar_image = null_resource.schema_loader_image_push[0].id
+  }
+
+  connection {
+    host        = var.bastion_host_ip
+    user        = var.user_name
+    agent       = true
+    private_key = file(var.private_key_path)
+  }
+
+  provisioner "remote-exec" {
+    inline = ["rsync -e 'ssh -o StrictHostKeyChecking=no' -cvv ${module.ansible.remote_playbook_path}/${local.schema_loader_image_filename} ${var.user_name}@${var.host_list[count.index]}:/tmp/"]
+  }
+}
+
 resource "null_resource" "schema_loader_image_load" {
   count = var.provision_count > 0 ? 1 : 0
 
@@ -158,11 +198,6 @@ resource "null_resource" "schema_loader_image_load" {
     user         = var.user_name
     agent        = true
     private_key  = file(var.private_key_path)
-  }
-
-  provisioner "file" {
-    source      = "${path.module}/${local.schema_loader_image_filename}"
-    destination = "/tmp/${local.schema_loader_image_filename}"
   }
 
   provisioner "remote-exec" {

--- a/modules/universal/scalardl/main.tf
+++ b/modules/universal/scalardl/main.tf
@@ -48,7 +48,7 @@ resource "null_resource" "schema_loader_image" {
 
   triggers = {
     schema_loader_image = var.schema_loader_image,
-    triggers            = null_resource.docker_install[count.index].id
+    triggers            = null_resource.docker_install[0].id
   }
 
   provisioner "local-exec" {
@@ -169,7 +169,7 @@ resource "null_resource" "schema_loader_push" {
   count = var.provision_count > 0 ? 1 : 0
 
   triggers = {
-    triggers     = null_resource.docker_install[count.index].id,
+    triggers     = null_resource.docker_install[0].id,
     scalar_image = null_resource.schema_loader_image_push[0].id
   }
 
@@ -181,7 +181,7 @@ resource "null_resource" "schema_loader_push" {
   }
 
   provisioner "remote-exec" {
-    inline = ["rsync -e 'ssh -o StrictHostKeyChecking=no' -cvv ${module.ansible.remote_playbook_path}/${local.schema_loader_image_filename} ${var.user_name}@${var.host_list[count.index]}:/tmp/"]
+    inline = ["rsync -e 'ssh -o StrictHostKeyChecking=no' -cvv ${module.ansible.remote_playbook_path}/${local.schema_loader_image_filename} ${var.user_name}@${var.host_list[0]}:/tmp/"]
   }
 }
 


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-8735
https://scalar-labs.atlassian.net/browse/DLT-8757

Errors occur when running taint on a different machine than the one used to build the environment.

- Replace node
```
terraformf taint "module.scalardl.module.scalardl_blue.module.cluster.azurerm_virtual_machine.vm-linux[0]"
terraformf taint "module.scalardl.module.scalardl_blue.module.scalardl_cluster.aws_instance.this[0]"
```

- Error
```
module.scalardl.module.scalardl_blue.module.scalardl_provision.null_resource.schema_loader_image_load[0] (remote-exec): gzip: /tmp/scalardl-schema-loader-1.3.0.tar.gz: No such file
```

📝  After merge this PR, we don't need #306

# Done
- Fix to copy schema loader image via bastion as well as scalardl image.
- Add trigger for recreate schema loader image.