### PR TITLE
Set context to allow logrotate for aggregated logs

### DIFF
--- a/provision/ansible/playbooks/monitor-server.yml
+++ b/provision/ansible/playbooks/monitor-server.yml
@@ -1,4 +1,12 @@
 ---
+- name: Common Install
+  hosts: all
+  roles:
+    - common
+    - node-exporter
+  gather_facts: yes
+  become: yes
+
 - name: Install td-agent
   hosts: all
   roles:
@@ -10,14 +18,6 @@
     tdagent_confd_templates:
       - { src: "templates/td-agent-confd/td-agent-monitor.conf.j2", dest: "monitor.conf" }
       - { src: "templates/td-agent-confd/metrics.conf.j2", dest: "metrics.conf" }
-  gather_facts: yes
-  become: yes
-
-- name: Common Install
-  hosts: all
-  roles:
-    - common
-    - node-exporter
   gather_facts: yes
   become: yes
 

--- a/provision/ansible/playbooks/monitor-server.yml
+++ b/provision/ansible/playbooks/monitor-server.yml
@@ -1,12 +1,4 @@
 ---
-- name: Common Install
-  hosts: all
-  roles:
-    - common
-    - node-exporter
-  gather_facts: yes
-  become: yes
-
 - name: Install td-agent
   hosts: all
   roles:
@@ -18,6 +10,14 @@
     tdagent_confd_templates:
       - { src: "templates/td-agent-confd/td-agent-monitor.conf.j2", dest: "monitor.conf" }
       - { src: "templates/td-agent-confd/metrics.conf.j2", dest: "metrics.conf" }
+  gather_facts: yes
+  become: yes
+
+- name: Common Install
+  hosts: all
+  roles:
+    - common
+    - node-exporter
   gather_facts: yes
   become: yes
 

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install policycoreutils
+  package:
+    name: policycoreutils-python
+    state: present
+
 - name: Copy Drive Mount Script
   copy:
     src: drive_mount.sh

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
@@ -23,7 +23,7 @@
     daemon_reload: yes
     state: started
 
-- name: Set context to allow logrotate for aggregated logs
+- name: Set SELinux file context for aggregated logs
   community.general.sefcontext:
     target: '/log(/.*)?(/.*)?(/*.log)?'
     setype: var_log_t

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
@@ -18,6 +18,12 @@
     daemon_reload: yes
     state: started
 
+- name: Set context to allow logrotate for aggregated logs
+  community.general.sefcontext:
+    target: '/log/*/*.log'
+    setype: var_log_t
+    state: present
+
 - name: Setup logrotate.d
   template:
     src: monitor.logrotate.j2

--- a/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/td-agent_aggregation/tasks/main.yml
@@ -20,9 +20,12 @@
 
 - name: Set context to allow logrotate for aggregated logs
   community.general.sefcontext:
-    target: '/log/*/*.log'
+    target: '/log(/.*)?(/.*)?(/*.log)?'
     setype: var_log_t
     state: present
+
+- name: Apply new SELinux file context to filesystem
+  command: restorecon -irv /log
 
 - name: Setup logrotate.d
   template:


### PR DESCRIPTION
# Description

- audit.log
```
type=AVC msg=audit(1621395361.770:100093): avc:  denied  { read } for  pid=8305 comm="logrotate" name="/" dev="sdc" ino=96 scontext=system_u:system_r:logrotate_t:s0-s0:c0.c1023 tcontext=
system_u:object_r:unlabeled_t:s0 tclass=dir permissive=0
type=SYSCALL msg=audit(1621395361.770:100093): arch=c000003e syscall=257 success=no exit=-13 a0=ffffffffffffff9c a1=7fff800ef3f0 a2=90800 a3=0 items=0 ppid=8303 pid=8305 auid=0 uid=0 gid
=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=13092 comm="logrotate" exe="/usr/sbin/logrotate" subj=system_u:system_r:logrotate_t:s0-s0:c0.c1023 key=(null)
type=PROCTITLE msg=audit(1621395361.770:100093): proctitle=2F7573722F7362696E2F6C6F67726F74617465002D73002F7661722F6C69622F6C6F67726F746174652F6C6F67726F746174652E737461747573002F6574632
F6C6F67726F746174652E636F6E66
```
https://access.redhat.com/solutions/39006

ansible sefcontext module:
https://docs.ansible.com/ansible/latest/collections/community/general/sefcontext_module.html

- After apply
```
[centos@monitor-1 ~]$ cat /etc/selinux/targeted/contexts/files/file_contexts.local
# This file is auto-generated by libsemanage
# Do not edit directly.

/log(/.*)?(/.*)?(/*.log)?    system_u:object_r:var_log_t:s0
```
```
[centos@monitor-1 ~]$ ls -Z /log/
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   bastion-1
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   buffer
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   cassandra-1
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   cassandra-2
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   cassandra-3
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   cassy-1
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   envoy-1
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   envoy-2
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   envoy-3
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   monitor-1
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   reaper-1
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   scalardl-blue-1
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   scalardl-blue-2
drwxr-xr-x. td-agent td-agent system_u:object_r:var_log_t:s0   scalardl-blue-3
```
logrotate works fine.
```
[root@monitor-1 bastion-1]# ll -h /log/scalardl-blue-1/
total 1.6G
-rw-r--r--. 1 td-agent td-agent  22M May 20 05:38 docker.log
-rw-r--r--. 1 td-agent td-agent 188M May 13 04:07 docker.log-20210513.gz
-rw-r--r--. 1 td-agent td-agent 1.4G May 20 03:33 docker.log-20210520.gz
-rw-r--r--. 1 td-agent td-agent    0 May 20 04:45 fluent.log
-rw-r--r--. 1 td-agent td-agent 3.5K May 13 03:32 fluent.log-20210513.gz
-rw-r--r--. 1 td-agent td-agent  748 May 20 03:16 fluent.log-20210520.gz
-rw-r--r--. 1 td-agent td-agent 5.6K May 20 05:30 system.log
-rw-r--r--. 1 td-agent td-agent 3.3M May 13 04:01 system.log-20210513.gz
-rw-r--r--. 1 td-agent td-agent 142K May 20 03:30 system.log-20210520.gz

[root@monitor-1 cassandra-1]# ll -h /log/cassandra-1/
total 37M
-rw-r--r--. 1 td-agent td-agent  10K May 20 05:40 cassandra.log
-rw-r--r--. 1 td-agent td-agent 3.1M May  7 05:06 cassandra.log-20210507.gz
-rw-r--r--. 1 td-agent td-agent 330K May 13 04:05 cassandra.log-20210513.gz
-rw-r--r--. 1 td-agent td-agent 269K May 20 03:30 cassandra.log-20210520.gz
-rw-r--r--. 1 td-agent td-agent  214 May 20 03:43 fluent.log
-rw-r--r--. 1 td-agent td-agent 3.5K May  7 03:11 fluent.log-20210507.gz
-rw-r--r--. 1 td-agent td-agent  406 May 13 04:03 fluent.log-20210513.gz
-rw-r--r--. 1 td-agent td-agent  446 May 19 03:35 fluent.log-20210520.gz
-rw-r--r--. 1 td-agent td-agent  46K May 20 05:40 system.log
-rw-r--r--. 1 td-agent td-agent  24M May  7 05:07 system.log-20210507.gz
-rw-r--r--. 1 td-agent td-agent 497K May 13 04:07 system.log-20210513.gz
-rw-r--r--. 1 td-agent td-agent 9.1M May 20 03:33 system.log-20210520.gz
```