### PR TITLE
Fix terraform refresh in docs

### DIFF
--- a/docs/HowToExpandAzureManagedDisk.md
+++ b/docs/HowToExpandAzureManagedDisk.md
@@ -75,8 +75,8 @@ Second, do `terraform plan` to check if Cloud resources' states are the same as 
 $ terraform plan -var-file=your.tfvars
 ```
 
-Third, do `terraform refresh` to update tfstate.
+Third, do `terraform apply` to update tfstate.
 
 ```console
-$ terraform refresh -var-file=your.tfvars
+$ terraform apply -var-file=your.tfvars
 ```

--- a/docs/HowToExpandEBS.md
+++ b/docs/HowToExpandEBS.md
@@ -2,7 +2,7 @@
 
 This guide explains how to expand EBS volumes in AWS.
 
-## Stop processes 
+## Stop processes
 
 Stop the processes of a node that you want to expand the volume of.
 
@@ -63,8 +63,8 @@ Second, do `terraform plan` to check if Cloud resources' states are the same as 
 $ terraform plan -var-file=your.tfvars
 ```
 
-Third, do `terraform refresh` to update tfstate.
+Third, do `terraform apply` to update tfstate.
 
 ```console
-$ terraform refresh -var-file=your.tfvars
+$ terraform apply -var-file=your.tfvars
 ```

--- a/docs/ShareEnvironment.md
+++ b/docs/ShareEnvironment.md
@@ -33,7 +33,7 @@ Then, update tfstate file as follows.
 ```
 cd /path/to/network
 terraform init
-terraform refresh -var-file=example.tfvars
+terraform apply -var-file=example.tfvars
 ```
 
 ## Update the tfstate of the cassandra, scalardl, and monitor modules
@@ -43,5 +43,5 @@ Then, do the following to reflect the above changes to each module.
 ```
 cd /path/to/[cassandra|scalardl|monitor]
 terraform init
-terraform refresh -var-file=example.tfvars
+terraform apply -var-file=example.tfvars
 ```


### PR DESCRIPTION
# Description
https://github.com/scalar-labs/scalar-terraform/pull/315#discussion_r639362264

`refresh` command is deprecated. Fix to use `apply` instead of `refresh`.

https://www.terraform.io/docs/cli/commands/refresh.html
```
Warning: This command is deprecated, because its default behavior is unsafe if you have misconfigured credentials for any of your providers. See below for more information and recommended alternatives.
```