### PR TITLE
Fix to use prefix version for azure k8s module

### DIFF
--- a/modules/azure/kubernetes/README.md
+++ b/modules/azure/kubernetes/README.md
@@ -39,7 +39,7 @@ The Azure Kubernetes Module creates a subnet for k8s, service principal, set per
 |------|-------------|------|---------|:--------:|
 | name | cluster name | `string` | `scalar-kubernetes` | no |
 | dns_prefix | dns prefix for the cluster | `string` | `scalar-k8s` | no |
-| kubernetes_version | kubernetes version | `string` | `1.19.7` | no|
+| kubernetes_version | kubernetes version | `string` | `1.19` | no|
 | admin_username | ssh user for node | `string` | `azureuser` | no |
 | role_based_access_control | activate RBAC in k8s | `string` | `true` | no |
 

--- a/modules/azure/kubernetes/data.tf
+++ b/modules/azure/kubernetes/data.tf
@@ -3,9 +3,7 @@ data "azurerm_subscription" "current" {
 }
 
 data "azurerm_kubernetes_service_versions" "current" {
-  count = local.kubernetes_cluster.kubernetes_version != null ? 0 : 1
-
   location        = local.kubernetes_cluster.region
-  version_prefix  = local.kubernetes_cluster.kubernetes_version_prefix
+  version_prefix  = local.kubernetes_cluster.kubernetes_version
   include_preview = false
 }

--- a/modules/azure/kubernetes/data.tf
+++ b/modules/azure/kubernetes/data.tf
@@ -1,5 +1,9 @@
+# Retrieve scope id for assignment
+data "azurerm_subscription" "current" {
+}
+
 data "azurerm_kubernetes_service_versions" "current" {
-  count = local.kubernetes_cluster.kubernetes_version != null ? 1 : 0
+  count = local.kubernetes_cluster.kubernetes_version != null ? 0 : 1
 
   location        = local.kubernetes_cluster.region
   version_prefix  = local.kubernetes_cluster.kubernetes_version_prefix

--- a/modules/azure/kubernetes/data.tf
+++ b/modules/azure/kubernetes/data.tf
@@ -1,0 +1,7 @@
+data "azurerm_kubernetes_service_versions" "current" {
+  count = local.kubernetes_cluster.kubernetes_version != null ? 1 : 0
+
+  location        = local.kubernetes_cluster.region
+  version_prefix  = local.kubernetes_cluster.kubernetes_version_prefix
+  include_preview = false
+}

--- a/modules/azure/kubernetes/kubernetes.tf
+++ b/modules/azure/kubernetes/kubernetes.tf
@@ -81,7 +81,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   resource_group_name     = local.kubernetes_cluster.resource_group_name
   location                = local.kubernetes_cluster.region
   dns_prefix              = local.kubernetes_cluster.dns_prefix
-  kubernetes_version      = local.kubernetes_cluster.kubernetes_version != null ? local.kubernetes_cluster.kubernetes_version : data.azurerm_kubernetes_service_versions.current[0].latest_version
+  kubernetes_version      = data.azurerm_kubernetes_service_versions.current.latest_version
   node_resource_group     = "${local.kubernetes_cluster.resource_group_name}_MC"
   private_cluster_enabled = !local.kubernetes_cluster.public_cluster_enabled
 
@@ -104,7 +104,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     enable_auto_scaling   = local.kubernetes_default_node_pool.cluster_auto_scaling
     min_count             = local.kubernetes_default_node_pool.cluster_auto_scaling ? local.kubernetes_default_node_pool.cluster_auto_scaling_min_count : null
     max_count             = local.kubernetes_default_node_pool.cluster_auto_scaling ? local.kubernetes_default_node_pool.cluster_auto_scaling_max_count : null
-    orchestrator_version  = local.kubernetes_cluster.kubernetes_version != null ? local.kubernetes_cluster.kubernetes_version : data.azurerm_kubernetes_service_versions.current[0].latest_version
+    orchestrator_version  = data.azurerm_kubernetes_service_versions.current.latest_version
   }
 
   role_based_access_control {

--- a/modules/azure/kubernetes/kubernetes.tf
+++ b/modules/azure/kubernetes/kubernetes.tf
@@ -85,7 +85,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
   resource_group_name     = local.kubernetes_cluster.resource_group_name
   location                = local.kubernetes_cluster.region
   dns_prefix              = local.kubernetes_cluster.dns_prefix
-  kubernetes_version      = local.kubernetes_cluster.kubernetes_version
+  kubernetes_version      = local.kubernetes_cluster.kubernetes_version != null ? local.kubernetes_cluster.kubernetes_version : data.azurerm_kubernetes_service_versions.current[0].latest_version
   node_resource_group     = "${local.kubernetes_cluster.resource_group_name}_MC"
   private_cluster_enabled = !local.kubernetes_cluster.public_cluster_enabled
 
@@ -108,6 +108,7 @@ resource "azurerm_kubernetes_cluster" "aks_cluster" {
     enable_auto_scaling   = local.kubernetes_default_node_pool.cluster_auto_scaling
     min_count             = local.kubernetes_default_node_pool.cluster_auto_scaling ? local.kubernetes_default_node_pool.cluster_auto_scaling_min_count : null
     max_count             = local.kubernetes_default_node_pool.cluster_auto_scaling ? local.kubernetes_default_node_pool.cluster_auto_scaling_max_count : null
+    orchestrator_version  = local.kubernetes_cluster.kubernetes_version != null ? local.kubernetes_cluster.kubernetes_version : data.azurerm_kubernetes_service_versions.current[0].latest_version
   }
 
   role_based_access_control {

--- a/modules/azure/kubernetes/kubernetes.tf
+++ b/modules/azure/kubernetes/kubernetes.tf
@@ -59,10 +59,6 @@ resource "azuread_service_principal_password" "sp_password" {
   }
 }
 
-# Retrieve scope id for assignment
-data "azurerm_subscription" "current" {
-}
-
 # Set assignment Contributor to Service Principal
 resource "azurerm_role_assignment" "sp_role_assignment" {
   scope                = "${data.azurerm_subscription.current.id}/resourceGroups/${local.network_name}"

--- a/modules/azure/kubernetes/locals.tf
+++ b/modules/azure/kubernetes/locals.tf
@@ -27,8 +27,7 @@ locals {
     resource_group_name       = var.network.name
     region                    = var.network.region
     dns_prefix                = "scalar-kubernetes"
-    kubernetes_version_prefix = "1.19"
-    kubernetes_version        = null
+    kubernetes_version        = "1.19"
     admin_username            = "azureuser"
     public_ssh_key_path       = var.network.public_key_path
     role_based_access_control = true

--- a/modules/azure/kubernetes/locals.tf
+++ b/modules/azure/kubernetes/locals.tf
@@ -27,7 +27,8 @@ locals {
     resource_group_name       = var.network.name
     region                    = var.network.region
     dns_prefix                = "scalar-kubernetes"
-    kubernetes_version        = "1.19.7"
+    kubernetes_version_prefix = "1.19"
+    kubernetes_version        = null
     admin_username            = "azureuser"
     public_ssh_key_path       = var.network.public_key_path
     role_based_access_control = true


### PR DESCRIPTION
# Description

Due to the fast-moving nature of AKS, we recommend using the latest version, So it is better to specify a prefix version like aws.

https://scalar-labs.atlassian.net/browse/DLT-9166

# Done
- Use the latest version searched by prefix.
- Add [orchestrator_version](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster_node_pool#orchestrator_version)
```
orchestrator_version - (Optional) Version of Kubernetes used for the Agents. If not specified, the latest recommended version will be used at provisioning time (but won't auto-upgrade)
```