### PR TITLE
Add max_connection_duration for Envoy balancing connections

### DIFF
--- a/modules/universal/envoy/provision/envoy.yaml.j2
+++ b/modules/universal/envoy/provision/envoy.yaml.j2
@@ -30,8 +30,8 @@ static_resources:
               codec_type: auto
               stat_prefix: ingress_http
               common_http_protocol_options:
-                idle_timeout: 300s
-                max_connection_duration: 60s
+                max_connection_duration: 300s
+              drain_timeout: 60s
               route_config:
                 name: scalar_route
                 virtual_hosts:

--- a/modules/universal/envoy/provision/envoy.yaml.j2
+++ b/modules/universal/envoy/provision/envoy.yaml.j2
@@ -29,6 +29,9 @@ static_resources:
                 - name: envoy.filters.http.router
               codec_type: auto
               stat_prefix: ingress_http
+              common_http_protocol_options:
+                idle_timeout: 300s
+                max_connection_duration: 60s
               route_config:
                 name: scalar_route
                 virtual_hosts:

--- a/modules/universal/envoy/provision/envoy.yaml.j2
+++ b/modules/universal/envoy/provision/envoy.yaml.j2
@@ -31,7 +31,6 @@ static_resources:
               stat_prefix: ingress_http
               common_http_protocol_options:
                 max_connection_duration: 300s
-              drain_timeout: 60s
               route_config:
                 name: scalar_route
                 virtual_hosts:


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-9226

### Background
As a Scalar DL user, I want it to use the deployed resources fully so that I can lower over all cost of my system.

### Current Issues
```
The downstream connections between clients and envoy pods could be imbalanced after some operations such as rolling update or some node/pod crashes.

Preliminary investigation by Suda-san. Please read it carefully before working on the task and ask questions as needed to clarify what is going on.

superbrothers/gistfile1.md 
```

# Done
Added envoy options.
- max_connection_duration : `300s`
- drain_timeout : `60s`

# TODO (other PR)
- Use `v3-api`
- Upgrade envoy version