### PR TITLE
Fix to use http resource instead of local-exec for eks health check

### DIFF
--- a/modules/aws/kubernetes/auth.tf
+++ b/modules/aws/kubernetes/auth.tf
@@ -42,27 +42,10 @@ provider "kubernetes" {
   load_config_file       = false
 }
 
-resource "null_resource" "wait_for_cluster" {
-  count = local.kubernetes_cluster.manage_aws_auth ? 1 : 0
-
-  depends_on = [
-    aws_eks_cluster.eks_cluster,
-    aws_security_group.eks_cluster
-  ]
-
-  provisioner "local-exec" {
-    command     = "curl --silent --fail --retry 60 --retry-delay 5 --retry-connrefused --insecure --output /dev/null $ENDPOINT/healthz"
-    interpreter = ["/bin/sh", "-c"]
-    environment = {
-      ENDPOINT = aws_eks_cluster.eks_cluster.endpoint
-    }
-  }
-}
-
 resource "kubernetes_config_map" "aws_auth" {
   count = local.kubernetes_cluster.manage_aws_auth ? 1 : 0
 
-  depends_on = [null_resource.wait_for_cluster[0]]
+  depends_on = [data.http.wait_for_cluster[0]]
 
   metadata {
     name      = "aws-auth"

--- a/modules/aws/kubernetes/data.tf
+++ b/modules/aws/kubernetes/data.tf
@@ -1,3 +1,16 @@
 data "aws_caller_identity" "current" {}
 
 data "aws_partition" "current" {}
+
+data "http" "wait_for_cluster" {
+  count = local.kubernetes_cluster.manage_aws_auth ? 1 : 0
+
+  url            = format("%s/healthz", aws_eks_cluster.eks_cluster.endpoint)
+  ca_certificate = base64decode(aws_eks_cluster.eks_cluster.certificate_authority[0].data)
+  timeout        = 300
+
+  depends_on = [
+    aws_eks_cluster.eks_cluster,
+    aws_security_group.eks_cluster
+  ]
+}

--- a/modules/aws/kubernetes/data.tf
+++ b/modules/aws/kubernetes/data.tf
@@ -5,12 +5,12 @@ data "aws_partition" "current" {}
 data "http" "wait_for_cluster" {
   count = local.kubernetes_cluster.manage_aws_auth ? 1 : 0
 
-  url            = format("%s/healthz", aws_eks_cluster.eks_cluster.endpoint)
-  ca_certificate = base64decode(aws_eks_cluster.eks_cluster.certificate_authority[0].data)
-  timeout        = 300
-
   depends_on = [
     aws_eks_cluster.eks_cluster,
     aws_security_group.eks_cluster
   ]
+
+  url            = format("%s/healthz", aws_eks_cluster.eks_cluster.endpoint)
+  ca_certificate = base64decode(aws_eks_cluster.eks_cluster.certificate_authority[0].data)
+  timeout        = 300
 }

--- a/modules/aws/kubernetes/versions.tf
+++ b/modules/aws/kubernetes/versions.tf
@@ -29,7 +29,7 @@ terraform {
 
     http = {
       source  = "terraform-aws-modules/http"
-      version = ">= 2.4.1"
+      version = "~> 2.4"
     }
   }
 }

--- a/modules/aws/kubernetes/versions.tf
+++ b/modules/aws/kubernetes/versions.tf
@@ -26,5 +26,10 @@ terraform {
       source  = "hashicorp/local"
       version = "~> 2.1"
     }
+
+    http = {
+      source  = "terraform-aws-modules/http"
+      version = ">= 2.4.1"
+    }
   }
 }

--- a/modules/aws/kubernetes/versions.tf
+++ b/modules/aws/kubernetes/versions.tf
@@ -7,11 +7,6 @@ terraform {
       version = "~> 2.70"
     }
 
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.1"
-    }
-
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 1.13"


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-8842

ref: https://github.com/terraform-aws-modules/terraform-aws-eks/pull/1339

Some resources are not deleted when destroy k8s module in terratest.
```
2021-07-11T15:51:05.4829239Z TestEndToEndK8s 2021-07-11T15:51:05Z command.go:158: module.kubernetes.module.scalardl_apps_pool.aws_eks_node_group.default[0]: Destruction complete after 3m16s
2021-07-11T15:51:05.4873649Z TestEndToEndK8s 2021-07-11T15:51:05Z command.go:158: module.kubernetes.kubernetes_config_map.aws_auth[0]: Destroying... [id=kube-system/aws-auth]
2021-07-11T15:51:05.5824998Z TestEndToEndK8s 2021-07-11T15:51:05Z command.go:158: 
2021-07-11T15:51:05.5842631Z TestEndToEndK8s 2021-07-11T15:51:05Z command.go:158: Error: Unauthorized
```

# Done
Fix to use data resource for health check

# Confirm
```
$ terraform destroy
・・・
module.kubernetes.module.scalardl_apps_pool.aws_eks_node_group.default[0]: Destruction complete after 3m20s
module.kubernetes.kubernetes_config_map.aws_auth[0]: Destroying... [id=kube-system/aws-auth]
module.kubernetes.kubernetes_config_map.aws_auth[0]: Destruction complete after 1s
module.kubernetes.module.scalardl_apps_pool.aws_iam_role.eks_node[0]: Destroying... [id=tei-k8s-x-fch-g-scalardlpool-eks-node]
module.kubernetes.module.default_node_pool.aws_iam_role.eks_node[0]: Destroying... [id=tei-k8s-x-fch-g-default-eks-node]
module.kubernetes.module.scalardl_apps_pool.aws_iam_role.eks_node[0]: Destruction complete after 3s
module.kubernetes.module.default_node_pool.aws_iam_role.eks_node[0]: Destruction complete after 3s
module.kubernetes.aws_eks_cluster.eks_cluster: Destroying... [id=tei-k8s-x-fch-g]
module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 10s elapsed]
module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 20s elapsed]                                                                                          module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 30s elapsed]                                                                                          module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 40s elapsed]                                                                                          module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 50s elapsed]                                                                                          module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 1m0s elapsed]                                                                                         module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 1m10s elapsed]                                                                                        module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 1m20s elapsed]                                                                                        module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 1m30s elapsed]
module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 1m40s elapsed]
module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 1m50s elapsed]
module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 2m0s elapsed]
module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 2m10s elapsed]
module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 2m20s elapsed]
module.kubernetes.aws_eks_cluster.eks_cluster: Still destroying... [id=tei-k8s-x-fch-g, 2m30s elapsed]
module.kubernetes.aws_eks_cluster.eks_cluster: Destruction complete after 2m38s
module.kubernetes.aws_iam_role.eks_cluster: Destroying... [id=tei-k8s-x-fch-g-eks-cluster]
module.kubernetes.aws_security_group.eks_cluster: Destroying... [id=sg-0275bdeea590c6bf5]
module.kubernetes.aws_security_group.eks_cluster: Destruction complete after 1s
module.kubernetes.aws_iam_role.eks_cluster: Destruction complete after 3s

Destroy complete! Resources: 24 destroyed.
```