### PR TITLE
Allow remote access to eks nodes

### DIFF
--- a/modules/aws/kubernetes/locals.tf
+++ b/modules/aws/kubernetes/locals.tf
@@ -49,7 +49,7 @@ locals {
     cluster_auto_scaling_max_count = "6"
     subnet_ids                     = local.private_subnet_ids
     kubernetes_labels              = {}
-    allow_remote_access            = true
+    enable_remote_access           = true
     ssh_key_name                   = var.network.ssh_key_name
     source_security_group_ids      = [var.network.bastion_security_group_id]
   }
@@ -73,7 +73,7 @@ locals {
     kubernetes_labels = {
       agentpool = "scalardlpool"
     }
-    allow_remote_access       = true
+    enable_remote_access      = true
     ssh_key_name              = var.network.ssh_key_name
     source_security_group_ids = [var.network.bastion_security_group_id]
   }

--- a/modules/aws/kubernetes/locals.tf
+++ b/modules/aws/kubernetes/locals.tf
@@ -49,6 +49,9 @@ locals {
     cluster_auto_scaling_max_count = "6"
     subnet_ids                     = local.private_subnet_ids
     kubernetes_labels              = {}
+    allow_remote_access            = true
+    ssh_key_name                   = var.network.key_name
+    source_security_group_ids      = [var.network.bastion_security_group_id]
   }
 
   kubernetes_default_node_pool = merge(
@@ -70,6 +73,9 @@ locals {
     kubernetes_labels = {
       agentpool = "scalardlpool"
     }
+    allow_remote_access       = true
+    ssh_key_name              = var.network.key_name
+    source_security_group_ids = [var.network.bastion_security_group_id]
   }
 
   kubernetes_scalar_apps_pool = merge(

--- a/modules/aws/kubernetes/locals.tf
+++ b/modules/aws/kubernetes/locals.tf
@@ -50,7 +50,7 @@ locals {
     subnet_ids                     = local.private_subnet_ids
     kubernetes_labels              = {}
     allow_remote_access            = true
-    ssh_key_name                   = var.network.key_name
+    ssh_key_name                   = var.network.ssh_key_name
     source_security_group_ids      = [var.network.bastion_security_group_id]
   }
 
@@ -74,7 +74,7 @@ locals {
       agentpool = "scalardlpool"
     }
     allow_remote_access       = true
-    ssh_key_name              = var.network.key_name
+    ssh_key_name              = var.network.ssh_key_name
     source_security_group_ids = [var.network.bastion_security_group_id]
   }
 

--- a/modules/aws/kubernetes/node_group/locals.tf
+++ b/modules/aws/kubernetes/node_group/locals.tf
@@ -1,13 +1,17 @@
 locals {
-  name             = var.node_group.name
-  desired_capacity = var.node_group.node_count
-  ami_type         = var.node_group.ami_type
-  disk_size        = var.node_group.os_disk_size_gb
-  instance_type    = var.node_group.instance_type
-  subnet_ids       = var.node_group.subnet_ids
-  # key_name         = var.node_group.key_name
-  max_capacity = var.node_group.cluster_auto_scaling_max_count
-  min_capacity = var.node_group.cluster_auto_scaling_min_count
+  name                      = var.node_group.name
+  desired_capacity          = var.node_group.node_count
+  ami_type                  = var.node_group.ami_type
+  disk_size                 = var.node_group.os_disk_size_gb
+  instance_type             = var.node_group.instance_type
+  subnet_ids                = var.node_group.subnet_ids
+  ssh_key_name              = var.node_group.ssh_key_name
+  allow_remote_access       = var.node_group.allow_remote_access
+  source_security_group_ids = var.node_group.source_security_group_ids
+  max_capacity              = var.node_group.cluster_auto_scaling_max_count
+  min_capacity              = var.node_group.cluster_auto_scaling_min_count
+
+
 
   policy_arn_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
 }

--- a/modules/aws/kubernetes/node_group/locals.tf
+++ b/modules/aws/kubernetes/node_group/locals.tf
@@ -11,7 +11,5 @@ locals {
   max_capacity              = var.node_group.cluster_auto_scaling_max_count
   min_capacity              = var.node_group.cluster_auto_scaling_min_count
 
-
-
   policy_arn_prefix = "arn:${data.aws_partition.current.partition}:iam::aws:policy"
 }

--- a/modules/aws/kubernetes/node_group/locals.tf
+++ b/modules/aws/kubernetes/node_group/locals.tf
@@ -6,7 +6,7 @@ locals {
   instance_type             = var.node_group.instance_type
   subnet_ids                = var.node_group.subnet_ids
   ssh_key_name              = var.node_group.ssh_key_name
-  allow_remote_access       = var.node_group.allow_remote_access
+  enable_remote_access      = var.node_group.enable_remote_access
   source_security_group_ids = var.node_group.source_security_group_ids
   max_capacity              = var.node_group.cluster_auto_scaling_max_count
   min_capacity              = var.node_group.cluster_auto_scaling_min_count

--- a/modules/aws/kubernetes/node_group/main.tf
+++ b/modules/aws/kubernetes/node_group/main.tf
@@ -18,9 +18,9 @@ resource "aws_eks_node_group" "default" {
   instance_types = [local.instance_type]
 
   dynamic "remote_access" {
-    for_each = var.allow_remote_access ? [{
-      ec2_ssh_key               = var.ssh_key_name
-      source_security_group_ids = var.source_security_group_ids
+    for_each = local.allow_remote_access ? [{
+      ec2_ssh_key               = local.ssh_key_name
+      source_security_group_ids = local.source_security_group_ids
     }] : []
 
     content {

--- a/modules/aws/kubernetes/node_group/main.tf
+++ b/modules/aws/kubernetes/node_group/main.tf
@@ -18,7 +18,7 @@ resource "aws_eks_node_group" "default" {
   instance_types = [local.instance_type]
 
   dynamic "remote_access" {
-    for_each = local.allow_remote_access ? [{
+    for_each = local.enable_remote_access ? [{
       ec2_ssh_key               = local.ssh_key_name
       source_security_group_ids = local.source_security_group_ids
     }] : []

--- a/modules/aws/kubernetes/node_group/main.tf
+++ b/modules/aws/kubernetes/node_group/main.tf
@@ -17,6 +17,18 @@ resource "aws_eks_node_group" "default" {
   disk_size      = local.disk_size
   instance_types = [local.instance_type]
 
+  dynamic "remote_access" {
+    for_each = var.allow_remote_access ? [{
+      ec2_ssh_key               = var.ssh_key_name
+      source_security_group_ids = var.source_security_group_ids
+    }] : []
+
+    content {
+      ec2_ssh_key               = remote_access.value["ec2_ssh_key"]
+      source_security_group_ids = remote_access.value["source_security_group_ids"]
+    }
+  }
+
   labels = var.kubernetes_labels
 
   tags = var.tags

--- a/modules/aws/network/output.tf
+++ b/modules/aws/network/output.tf
@@ -51,6 +51,11 @@ output "bastion_ip" {
   description = "Public IP address to bastion host"
 }
 
+output "bastion_security_group_id" {
+  value       = module.bastion.bastion_security_group_id
+  description = "The security group ID of the bastion resource."
+}
+
 output "locations" {
   value       = local.locations
   description = "The AWS availability zones to deploy environment."


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-8564

Implement for ssh access to eks nodes.

# Confirm
- ssh to bastion
```
$ ssh -FA ssh.cfg bastion
```
- bastion to eks nodes
```
[centos@bastion-1 ~]$ kubectl get nodes -o wide
NAME                                         STATUS   ROLES    AGE     VERSION              INTERNAL-IP    EXTERNAL-IP   OS-IMAGE         KERNEL-VERSION                CONTAINER-RUNTIME
ip-10-42-1-138.us-west-2.compute.internal    Ready    <none>   7m55s   v1.19.6-eks-49a6c0   10.42.1.138    <none>        Amazon Linux 2   5.4.117-58.216.amzn2.x86_64   docker://19.3.13
ip-10-42-1-16.us-west-2.compute.internal     Ready    <none>   7m52s   v1.19.6-eks-49a6c0   10.42.1.16     <none>        Amazon Linux 2   5.4.117-58.216.amzn2.x86_64   docker://19.3.13
ip-10-42-1-77.us-west-2.compute.internal     Ready    <none>   7m38s   v1.19.6-eks-49a6c0   10.42.1.77     <none>        Amazon Linux 2   5.4.117-58.216.amzn2.x86_64   docker://19.3.13
ip-10-42-40-39.us-west-2.compute.internal    Ready    <none>   10m     v1.19.6-eks-49a6c0   10.42.40.39    <none>        Amazon Linux 2   5.4.117-58.216.amzn2.x86_64   docker://19.3.13
ip-10-42-41-79.us-west-2.compute.internal    Ready    <none>   10m     v1.19.6-eks-49a6c0   10.42.41.79    <none>        Amazon Linux 2   5.4.117-58.216.amzn2.x86_64   docker://19.3.13
ip-10-42-42-196.us-west-2.compute.internal   Ready    <none>   10m     v1.19.6-eks-49a6c0   10.42.42.196   <none>        Amazon Linux 2   5.4.117-58.216.amzn2.x86_64   docker://19.3.13
[centos@bastion-1 ~]$ ssh ec2-user@10.42.1.138
The authenticity of host '10.42.1.138 (10.42.1.138)' can't be established.
ECDSA key fingerprint is SHA256:qWvqrHmBYjjmTLbQXxHW79BG+yFbGO9TmKA+5pxaO1s.
ECDSA key fingerprint is MD5:86:8c:a2:99:1d:9d:35:b9:ad:d3:5d:93:10:68:8d:07.
Are you sure you want to continue connecting (yes/no)? yes
Warning: Permanently added '10.42.1.138' (ECDSA) to the list of known hosts.
Last login: Mon Jun 28 16:39:27 2021 from 205.251.233.52

       __|  __|_  )
       _|  (     /   Amazon Linux 2 AMI
      ___|\___|___|

https://aws.amazon.com/amazon-linux-2/
2 package(s) needed for security, out of 12 available
Run "sudo yum update" to apply all updates.
[ec2-user@ip-10-42-1-138 ~]$ ls
[ec2-user@ip-10-42-1-138 ~]$ docker ps
CONTAINER ID        IMAGE                                                                   COMMAND                  CREATED             STATUS              PORTS               NAMES
d06bd8346716        602401143452.dkr.ecr.us-west-2.amazonaws.com/amazon-k8s-cni             "/bin/sh -c /app/ent…"   8 minutes ago       Up 8 minutes                            k8s_aws-node_aws-node-5vdzm_kube-system_8e441cf1-0501-4247-8903-80d189b74c2c_0
f0403853ec87        602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy             "kube-proxy --v=2 --…"   8 minutes ago       Up 8 minutes                            k8s_kube-proxy_kube-proxy-s4sw8_kube-system_732e7fa8-acee-46e3-a0df-ad8e4ef4f31a_0
0f261a425893        602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.1-eksbuild.1   "/pause"                 8 minutes ago       Up 8 minutes                            k8s_POD_kube-proxy-s4sw8_kube-system_732e7fa8-acee-46e3-a0df-ad8e4ef4f31a_0
fdfca9863c6b        602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/pause:3.1-eksbuild.1   "/pause"                 8 minutes ago       Up 8 minutes                            k8s_POD_aws-node-5vdzm_kube-system_8e441cf1-0501-4247-8903-80d189b74c2c_0
```