### PR TITLE
Fix default version of pip3 to 21.1.3

### DIFF
--- a/provision/ansible/playbooks/roles/common/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/common/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+pip_version: 21.1.3
 pip_packages:
   - j2cli
 

--- a/provision/ansible/playbooks/roles/common/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/common/tasks/main.yml
@@ -9,7 +9,8 @@
   pip:
     name: pip
     executable: pip3
-    state: latest
+    state: present
+    version: "{{ pip_version }}"
 
 - name: Install required packages via pip
   pip:


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-9543
https://scalar-labs.atlassian.net/browse/DLT-9544

```
TestEndToEndTerraform 2021-07-25T15:12:30Z command.go:158: module.network.module.bastion.module.bastion_provision.null_resource.ansible (local-exec): fatal: [bastion-1-terratest-adlniey.westus.cloudapp.azure.com]: FAILED! => {"changed": false, "cmd": ["/bin/pip3", "install", "ansible"], "msg": "stdout: Collecting ansible\n  Downloading ansible-4.3.0.tar.gz (35.1 MB)\nCollecting ansible-core<2.12,>=2.11.3\n  Downloading ansible-core-2.11.3.tar.gz (6.8 MB)\n\n:stderr: WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.\nPlease see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.\nTo avoid this problem you can invoke Python with '-m pip' instead of running pip directly.\nWARNING: Value for scheme.platlib does not match. Please report this to <https://github.com/pypa/pip/issues/10151>\ndistutils: /usr/local/lib64/python3.6/site-packages\nsysconfig: /usr/lib64/python3.6/site-packages\nWARNING: Value for scheme.purelib does not match. Please report this to <https://github.com/pypa/pip/issues/10151>\ndistutils: /usr/local/lib/python3.6/site-packages\nsysconfig: /usr/lib/python3.6/site-packages\nWARNING: Value for scheme.headers does not match. Please report this to <https://github.com/pypa/pip/issues/10151>\ndistutils: /usr/local/include/python3.6m/UNKNOWN\nsysconfig: /usr/include/python3.6m/UNKNOWN\nWARNING: Value for scheme.scripts does not match. Please report this to <https://github.com/pypa/pip/issues/10151>\ndistutils: /usr/local/bin\nsysconfig: /usr/bin\nWARNING: Value for scheme.data does not match. Please report this to <https://github.com/pypa/pip/issues/10151>\ndistutils: /usr/local\nsysconfig: /usr\nWARNING: Additional context:\nuser = False\nhome = None\nroot = None\nprefix = None\nERROR: Exception:\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/cli/base_command.py\", line 173, in _main\n    status = self.run(options, args)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/cli/req_command.py\", line 203, in wrapper\n    return func(self, options, args)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/commands/install.py\", line 316, in run\n    reqs, check_supported_wheels=not options.target_dir\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/resolution/resolvelib/resolver.py\", line 95, in resolve\n    collected.requirements, max_rounds=try_to_avoid_resolution_too_deep\n  File \"/usr/local/lib/python3.6/site-packages/pip/_vendor/resolvelib/resolvers.py\", line 472, in resolve\n    state = resolution.resolve(requirements, max_rounds=max_rounds)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_vendor/resolvelib/resolvers.py\", line 366, in resolve\n    failure_causes = self._attempt_to_pin_criterion(name)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_vendor/resolvelib/resolvers.py\", line 212, in _attempt_to_pin_criterion\n    criteria = self._get_updated_criteria(candidate)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_vendor/resolvelib/resolvers.py\", line 203, in _get_updated_criteria\n    self._add_to_criteria(criteria, requirement, parent=candidate)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_vendor/resolvelib/resolvers.py\", line 172, in _add_to_criteria\n    if not criterion.candidates:\n  File \"/usr/local/lib/python3.6/site-packages/pip/_vendor/resolvelib/structs.py\", line 151, in __bool__\n    return bool(self._sequence)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/resolution/resolvelib/found_candidates.py\", line 140, in __bool__\n    return any(self)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/resolution/resolvelib/found_candidates.py\", line 128, in <genexpr>\n    return (c for c in iterator if id(c) not in self._incompatible_ids)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/resolution/resolvelib/found_candidates.py\", line 32, in _iter_built\n    candidate = func()\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/resolution/resolvelib/factory.py\", line 209, in _make_candidate_from_link\n    version=version,\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 301, in __init__\n    version=version,\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 156, in __init__\n    self.dist = self._prepare()\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 227, in _prepare\n    dist = self._prepare_distribution()\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/resolution/resolvelib/candidates.py\", line 306, in _prepare_distribution\n    self._ireq, parallel_builds=True\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/operations/prepare.py\", line 508, in prepare_linked_requirement\n    return self._prepare_linked_requirement(req, parallel_builds)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/operations/prepare.py\", line 552, in _prepare_linked_requirement\n    self.download_dir, hashes\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/operations/prepare.py\", line 249, in unpack_url\n    unpack_file(file.path, location, file.content_type)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/utils/unpacking.py\", line 256, in unpack_file\n    untar_file(filename, location)\n  File \"/usr/local/lib/python3.6/site-packages/pip/_internal/utils/unpacking.py\", line 226, in untar_file\n    with open(path, \"wb\") as destfp:\nUnicodeEncodeError: 'ascii' codec can't encode character '\\xe9' in position 117: ordinal not in range(128)\n"}
```

https://github.com/pypa/pip/issues/10151


# Done
Fix the version of pip3 as a workaround.

# Confirm

```
[centos@bastion-1 ~]$ pip3 --version
pip 21.1.3 from /usr/local/lib/python3.6/site-packages/pip (python 3.6)
[centos@bastion-1 ~]$ ansible --version
[DEPRECATION WARNING]: Ansible will require Python 3.8 or newer on the controller starting with Ansible 2.12. Current version: 3.6.8 (default, Nov 16 2020, 16:55:22) [GCC 4.8.5
20150623 (Red Hat 4.8.5-44)]. This feature will be removed from ansible-core in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
ansible [core 2.11.3]
  config file = None
  configured module search path = ['/home/centos/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  ansible collection location = /home/centos/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.6.8 (default, Nov 16 2020, 16:55:22) [GCC 4.8.5 20150623 (Red Hat 4.8.5-44)]
  jinja version = 3.0.1
  libyaml = True
```