### PR TITLE
Fix deprecated attribute in azure kubernetes module

### DIFF
--- a/modules/azure/kubernetes/kubernetes.tf
+++ b/modules/azure/kubernetes/kubernetes.tf
@@ -22,9 +22,9 @@ resource "random_id" "id" {
 
 # Create application for Service Principals
 resource "azuread_application" "app" {
-  display_name               = "scalar-k8s-app-${local.network_name}-${random_id.id.b64_url}"
-  identifier_uris            = ["https://aks-${local.network_name}-${random_id.id.b64_url}"]
-  sign_in_audience           = "AzureADMyOrg"
+  display_name     = "scalar-k8s-app-${local.network_name}-${random_id.id.b64_url}"
+  identifier_uris  = ["https://aks-${local.network_name}-${random_id.id.b64_url}"]
+  sign_in_audience = "AzureADMyOrg"
 
   web {
     homepage_url  = "https://aks-${local.network_name}-${random_id.id.b64_url}"

--- a/modules/azure/kubernetes/kubernetes.tf
+++ b/modules/azure/kubernetes/kubernetes.tf
@@ -23,12 +23,17 @@ resource "random_id" "id" {
 # Create application for Service Principals
 resource "azuread_application" "app" {
   display_name               = "scalar-k8s-app-${local.network_name}-${random_id.id.b64_url}"
-  homepage                   = "https://aks-${local.network_name}-${random_id.id.b64_url}"
   identifier_uris            = ["https://aks-${local.network_name}-${random_id.id.b64_url}"]
-  reply_urls                 = ["https://aks-${local.network_name}-${random_id.id.b64_url}"]
-  available_to_other_tenants = false
-  oauth2_allow_implicit_flow = false
+  sign_in_audience           = "AzureADMyOrg"
 
+  web {
+    homepage_url  = "https://aks-${local.network_name}-${random_id.id.b64_url}"
+    redirect_uris = ["https://aks-${local.network_name}-${random_id.id.b64_url}"]
+
+    implicit_grant {
+      access_token_issuance_enabled = true
+    }
+  }
   # Waiting for AAD global replication - see https://github.com/Azure/AKS/issues/1206#issue-493516902
   provisioner "local-exec" {
     command = "sleep 60"

--- a/modules/azure/kubernetes/kubernetes.tf
+++ b/modules/azure/kubernetes/kubernetes.tf
@@ -31,7 +31,7 @@ resource "azuread_application" "app" {
     redirect_uris = ["https://aks-${local.network_name}-${random_id.id.b64_url}"]
 
     implicit_grant {
-      access_token_issuance_enabled = true
+      access_token_issuance_enabled = false
     }
   }
   # Waiting for AAD global replication - see https://github.com/Azure/AKS/issues/1206#issue-493516902


### PR DESCRIPTION
# Description

```
Warning: Attribute is deprecated

  on .terraform/modules/kubernetes/modules/azure/kubernetes/kubernetes.tf line 26, in resource "azuread_application" "app":
  26:   homepage                   = "https://aks-${local.network_name}-${random_id.id.b64_url}"

[NOTE] This attribute will be replaced by a new attribute `homepage_url` in
the `web` block in version 2.0 of the AzureAD provider

(and 2 more similar warnings elsewhere)


Warning: Deprecated Attribute

  on .terraform/modules/kubernetes/modules/azure/kubernetes/kubernetes.tf line 29, in resource "azuread_application" "app":
  29:   available_to_other_tenants = false

[NOTE] This attribute will be replaced by a new property `sign_in_audience` in
version 2.0 of the AzureAD provider

(and one more similar warning elsewhere)
```


Still have the following warning, I'll do it in other PR.
```
Warning: Attribute is deprecated

  on .terraform/modules/kubernetes/modules/azure/kubernetes/kubernetes.tf line 57, in resource "azuread_service_principal_password" "sp_password":
  57:   value                = random_password.aks_service_principal_password.result

In version 2.0 of the AzureAD provider, this attribute will become read-only
as it will no longer be possible to specify a password value. It will be
generated by Azure Active Directory and persisted to state for reuse in your
Terraform configuration.
```