### PR TITLE
Update credential api version to v1beta1 for eks

### DIFF
--- a/modules/aws/kubernetes/locals.tf
+++ b/modules/aws/kubernetes/locals.tf
@@ -94,6 +94,7 @@ locals {
       kubeconfig_name                   = local.kubeconfig_name
       endpoint                          = aws_eks_cluster.eks_cluster.endpoint
       cluster_auth_base64               = aws_eks_cluster.eks_cluster.certificate_authority[0].data
+      aws_authenticator_api_version     = "client.authentication.k8s.io/v1beta1"
       aws_authenticator_command         = "aws"
       aws_authenticator_command_args    = ["eks", "get-token", "--cluster-name", aws_eks_cluster.eks_cluster.name]
       aws_authenticator_additional_args = ["--region", local.region]

--- a/modules/aws/kubernetes/templates/kubeconfig.tpl
+++ b/modules/aws/kubernetes/templates/kubeconfig.tpl
@@ -20,7 +20,7 @@ users:
 - name: ${kubeconfig_name}
   user:
     exec:
-      apiVersion: client.authentication.k8s.io/v1alpha1
+      apiVersion: ${aws_authenticator_api_version}
       command: ${aws_authenticator_command}
       args:
 %{~ for i in aws_authenticator_command_args }


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-9588
https://scalar-labs.atlassian.net/browse/DLT-9622
https://scalar-labs.atlassian.net/browse/DLT-9623
https://scalar-labs.atlassian.net/browse/DLT-9624

```
TestEndToEndK8s 2021-07-29T15:43:29Z command.go:158: fatal: [34.203.209.5]: FAILED! => {"changed": false, "msg": "Failed to get client due to 403\nReason: Forbidden\nHTTP response headers: HTTPHeaderDict({'Audit-Id': '69dc5244-8dd9-4fe6-9bfb-dabc8955c970', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'Date': 'Thu, 29 Jul 2021 15:43:28 GMT', 'Content-Length': '189'})\nHTTP response body: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"forbidden: User \\\\\"system:anonymous\\\\\" cannot get path \\\\\"/apis\\\\\"\",\"reason\":\"Forbidden\",\"details\":{},\"code\":403}\\n'\nOriginal traceback: \n  File \"/usr/local/lib/python3.6/site-packages/openshift/dynamic/client.py\", line 42, in inner\n    resp = func(self, *args, **kwargs)\n\n  File \"/usr/local/lib/python3.6/site-packages/openshift/dynamic/client.py\", line 249, in request\n    _return_http_data_only=params.get('_return_http_data_only', True)\n\n  File \"/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py\", line 353, in call_api\n    _preload_content, _request_timeout, _host)\n\n  File \"/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py\", line 184, in __call_api\n    _request_timeout=_request_timeout)\n\n  File \"/usr/local/lib/python3.6/site-packages/kubernetes/client/api_client.py\", line 377, in request\n    headers=headers)\n\n  File \"/usr/local/lib/python3.6/site-packages/kubernetes/client/rest.py\", line 243, in GET\n    query_params=query_params)\n\n  File \"/usr/local/lib/python3.6/site-packages/kubernetes/client/rest.py\", line 233, in request\n    raise ApiException(http_resp=r)\n"}
```

```
$ kubectl get po
Unable to connect to the server: getting credentials: exec plugin is configured to use API version client.authentication.k8s.io/v1alpha1, plugin returned version client.authentication.k8s.io/v1beta1
```

ref: https://github.com/aws/aws-cli/pull/6289

# Done
- Update api version to `v1veta1`.

# Confirm
```
TASK [scalardl : Check if docker-registry secrets exists in Kubernetes] ***********************************************************************************************************
ok: [54.213.112.199]

TASK [scalardl : Add docker-registry secrets in Kubernetes] ***********************************************************************************************************************
changed: [54.213.112.199]

TASK [scalardl : Install Helm Diff] ***********************************************************************************************************************************************
ok: [54.213.112.199]
```