### PR TITLE
Update credential api version to v1alpha1 for eks

### DIFF
--- a/modules/aws/kubernetes/locals.tf
+++ b/modules/aws/kubernetes/locals.tf
@@ -94,7 +94,7 @@ locals {
       kubeconfig_name                   = local.kubeconfig_name
       endpoint                          = aws_eks_cluster.eks_cluster.endpoint
       cluster_auth_base64               = aws_eks_cluster.eks_cluster.certificate_authority[0].data
-      aws_authenticator_api_version     = "client.authentication.k8s.io/v1beta1"
+      aws_authenticator_api_version     = "client.authentication.k8s.io/v1alpha1"
       aws_authenticator_command         = "aws"
       aws_authenticator_command_args    = ["eks", "get-token", "--cluster-name", aws_eks_cluster.eks_cluster.name]
       aws_authenticator_additional_args = ["--region", local.region]


### PR DESCRIPTION
# Description
https://scalar-labs.atlassian.net/browse/DLT-9641

```
Unable to connect to the server: getting credentials: exec plugin is configured to use API version client.authentication.k8s.io/v1beta1, plugin returned version client.authentication.k8s.io/v1alpha1
```

refs:
- #327 
- https://github.com/aws/aws-cli/pull/6309/

# Done
- Update api version to `v1alpha1`

