### PR TITLE
Fix ansible version to 2.11.x

### DIFF
--- a/provision/ansible/playbooks/roles/ansible/defaults/main.yml
+++ b/provision/ansible/playbooks/roles/ansible/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+ansible_version: 2.11.x
+
+pip_package: python3-pip
+pip_executable: pip3

--- a/provision/ansible/playbooks/roles/ansible/tasks/main.yml
+++ b/provision/ansible/playbooks/roles/ansible/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
+- name: Ensure pip3 is installed.
+  package:
+    name: "{{ pip_package }}"
+    state: present
+
 - name: Install Ansible
   pip:
     name: ansible
     state: present
-    executable: pip3
+    version: "{{ ansible_version }}"
+    executable: "{{ pip_executable }}"


### PR DESCRIPTION
# Description

https://scalar-labs.atlassian.net/browse/DLT-9550

ansible-core 2.12 and Ansible 5.0.0 will require Python 3.8 or newer to function on the control node.
https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#control-node-requirements

So fix to use `2.11.x` for ansible in bastion.