### PR TITLE
Modify bastion default resource type for Azure

### DIFF
--- a/modules/azure/network/locals.tf
+++ b/modules/azure/network/locals.tf
@@ -1,7 +1,7 @@
 ### default
 locals {
   network_default = {
-    bastion_resource_type                 = "Standard_B1s"
+    bastion_resource_type                 = "Standard_B2s"
     bastion_resource_count                = 1
     bastion_access_cidr                   = "0.0.0.0/0"
     bastion_resource_root_volume_size     = 32


### PR DESCRIPTION
## Summary
- Changed the default instance type because there were cases where the memory of `bastion` was not enough when building infrastructure.

<img width="387" src="https://user-images.githubusercontent.com/301510/138788436-6d7dbd87-ab4a-43c5-9586-795816911031.png">


